### PR TITLE
Sheets quickstart fixes

### DIFF
--- a/sheets/quickstart/quickstart.rb
+++ b/sheets/quickstart/quickstart.rb
@@ -17,6 +17,9 @@ require 'googleauth'
 require 'googleauth/stores/file_token_store'
 require 'fileutils'
 
+# Force command-line prompts to show up immediately.
+$stdout.sync = true
+
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
 APPLICATION_NAME = 'Google Sheets API Ruby Quickstart'.freeze
 CLIENT_SECRETS_PATH = 'client_secret.json'.freeze

--- a/sheets/quickstart/quickstart.rb
+++ b/sheets/quickstart/quickstart.rb
@@ -62,7 +62,7 @@ range = 'Class Data!A2:E'
 response = service.get_spreadsheet_values(spreadsheet_id, range)
 puts 'Name, Major:'
 puts 'No data found.' if response.values.empty?
-response.each_values do |row|
+response.values.each do |row|
   # Print columns A and E, which correspond to indices 0 and 4.
   puts "#{row[0]}, #{row[4]}"
 end


### PR DESCRIPTION
Fixes some issues I found while running the quickstart on a Windows machine:

* prompt wasn't being displayed
* `each_values` iteration failed with `undefined method `each_values' for #<Google::Apis::SheetsV4::ValueRange:0x0000000004af9ae8> (NoMethodError)`