### PR TITLE
update the file name for client_secret

### DIFF
--- a/calendar/quickstart/quickstart.rb
+++ b/calendar/quickstart/quickstart.rb
@@ -19,7 +19,7 @@ require 'fileutils'
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
 APPLICATION_NAME = 'Google Calendar API Ruby Quickstart'.freeze
-CLIENT_SECRETS_PATH = 'client_secrets.json'.freeze
+CLIENT_SECRETS_PATH = 'client_secret.json'.freeze
 CREDENTIALS_PATH = 'token.yaml'.freeze
 SCOPE = Google::Apis::CalendarV3::AUTH_CALENDAR_READONLY
 


### PR DESCRIPTION
The documentation says the file should be called client_secret, not client_secrets ( https://developers.google.com/calendar/quickstart/ruby )