### PR TITLE
Update the filename of the developer credentials.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Temporary Items
 # Secrets
 client_secret.json
 application_credentials.json
-
+credentials.json
 token.yaml
+
 .ruby-version

--- a/admin_sdk/directory/quickstart.rb
+++ b/admin_sdk/directory/quickstart.rb
@@ -19,8 +19,8 @@ require 'fileutils'
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
 APPLICATION_NAME = 'Directory API Ruby Quickstart'.freeze
-CLIENT_SECRETS_PATH = 'client_secrets.json'.freeze
-CREDENTIALS_PATH = 'token.yaml'.freeze
+CREDENTIALS_PATH = 'credentials.json'.freeze
+TOKEN_PATH = 'token.yaml'.freeze
 SCOPE = Google::Apis::AdminDirectoryV1::AUTH_ADMIN_DIRECTORY_USER_READONLY
 
 ##
@@ -30,8 +30,8 @@ SCOPE = Google::Apis::AdminDirectoryV1::AUTH_ADMIN_DIRECTORY_USER_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CLIENT_SECRETS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: CREDENTIALS_PATH)
+  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
+  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
   authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
   user_id = 'default'
   credentials = authorizer.get_credentials(user_id)

--- a/admin_sdk/reports/quickstart.rb
+++ b/admin_sdk/reports/quickstart.rb
@@ -19,8 +19,8 @@ require 'fileutils'
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
 APPLICATION_NAME = 'Reports API Ruby Quickstart'.freeze
-CLIENT_SECRETS_PATH = 'client_secrets.json'.freeze
-CREDENTIALS_PATH = 'token.yaml'.freeze
+CREDENTIALS_PATH = 'credentials.json'.freeze
+TOKEN_PATH = 'token.yaml'.freeze
 SCOPE = Google::Apis::AdminReportsV1::AUTH_ADMIN_REPORTS_AUDIT_READONLY
 
 ##
@@ -30,8 +30,8 @@ SCOPE = Google::Apis::AdminReportsV1::AUTH_ADMIN_REPORTS_AUDIT_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CLIENT_SECRETS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: CREDENTIALS_PATH)
+  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
+  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
   authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
   user_id = 'default'
   credentials = authorizer.get_credentials(user_id)

--- a/admin_sdk/reseller/quickstart.rb
+++ b/admin_sdk/reseller/quickstart.rb
@@ -19,8 +19,8 @@ require 'fileutils'
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
 APPLICATION_NAME = 'Reseller API Ruby Quickstart'.freeze
-CLIENT_SECRETS_PATH = 'client_secrets.json'.freeze
-CREDENTIALS_PATH = 'token.yaml'.freeze
+CREDENTIALS_PATH = 'credentials.json'.freeze
+TOKEN_PATH = 'token.yaml'.freeze
 SCOPE = Google::Apis::ResellerV1::AUTH_APPS_ORDER
 
 ##
@@ -30,8 +30,8 @@ SCOPE = Google::Apis::ResellerV1::AUTH_APPS_ORDER
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CLIENT_SECRETS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: CREDENTIALS_PATH)
+  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
+  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
   authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
   user_id = 'default'
   credentials = authorizer.get_credentials(user_id)

--- a/apps_script/quickstart/quickstart.rb
+++ b/apps_script/quickstart/quickstart.rb
@@ -19,8 +19,8 @@ require 'fileutils'
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
 APPLICATION_NAME = 'Google Apps Script API Ruby Quickstart'.freeze
-CLIENT_SECRETS_PATH = 'client_secret.json'.freeze
-CREDENTIALS_PATH = 'token.yaml'.freeze
+CREDENTIALS_PATH = 'credentials.json'.freeze
+TOKEN_PATH = 'token.yaml'.freeze
 SCOPE = 'https://www.googleapis.com/auth/script.projects'.freeze
 
 ##
@@ -30,8 +30,8 @@ SCOPE = 'https://www.googleapis.com/auth/script.projects'.freeze
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CLIENT_SECRETS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: CREDENTIALS_PATH)
+  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
+  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
   authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
   user_id = 'default'
   credentials = authorizer.get_credentials(user_id)

--- a/calendar/quickstart/quickstart.rb
+++ b/calendar/quickstart/quickstart.rb
@@ -19,8 +19,8 @@ require 'fileutils'
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
 APPLICATION_NAME = 'Google Calendar API Ruby Quickstart'.freeze
-CLIENT_SECRETS_PATH = 'client_secrets.json'.freeze
-CREDENTIALS_PATH = 'token.yaml'.freeze
+CREDENTIALS_PATH = 'credentials.json'.freeze
+TOKEN_PATH = 'token.yaml'.freeze
 SCOPE = Google::Apis::CalendarV3::AUTH_CALENDAR_READONLY
 
 ##
@@ -30,8 +30,8 @@ SCOPE = Google::Apis::CalendarV3::AUTH_CALENDAR_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CLIENT_SECRETS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: CREDENTIALS_PATH)
+  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
+  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
   authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
   user_id = 'default'
   credentials = authorizer.get_credentials(user_id)

--- a/classroom/quickstart/quickstart.rb
+++ b/classroom/quickstart/quickstart.rb
@@ -19,8 +19,8 @@ require 'fileutils'
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
 APPLICATION_NAME = 'Classroom API Ruby Quickstart'.freeze
-CLIENT_SECRETS_PATH = 'client_secrets.json'.freeze
-CREDENTIALS_PATH = 'token.yaml'.freeze
+CREDENTIALS_PATH = 'credentials.json'.freeze
+TOKEN_PATH = 'token.yaml'.freeze
 SCOPE = Google::Apis::ClassroomV1::AUTH_CLASSROOM_COURSES_READONLY
 
 ##
@@ -30,8 +30,8 @@ SCOPE = Google::Apis::ClassroomV1::AUTH_CLASSROOM_COURSES_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CLIENT_SECRETS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: CREDENTIALS_PATH)
+  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
+  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
   authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
   user_id = 'default'
   credentials = authorizer.get_credentials(user_id)

--- a/drive/activity/quickstart.rb
+++ b/drive/activity/quickstart.rb
@@ -19,13 +19,9 @@ require 'fileutils'
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
 APPLICATION_NAME = 'G Suite Activity API Ruby Quickstart'.freeze
-CLIENT_SECRETS_PATH = 'client_secret.json'.freeze
-CREDENTIALS_PATH = File.join(Dir.home, '.credentials',
-                             'appsactivity-ruby-quickstart.yaml')
-SCOPE = [
-  Google::Apis::AppsactivityV1::AUTH_ACTIVITY,
-  Google::Apis::AppsactivityV1::AUTH_DRIVE_METADATA_READONLY
-].freeze
+CREDENTIALS_PATH = 'credentials.json'.freeze
+TOKEN_PATH = 'token.yaml'.freeze
+SCOPE = Google::Apis::AppsactivityV1::AUTH_ACTIVITY
 
 ##
 # Ensure valid credentials, either by restoring from the saved credentials
@@ -34,18 +30,15 @@ SCOPE = [
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  FileUtils.mkdir_p(File.dirname(CREDENTIALS_PATH))
-
-  client_id = Google::Auth::ClientId.from_file(CLIENT_SECRETS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: CREDENTIALS_PATH)
+  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
+  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
   authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
   user_id = 'default'
   credentials = authorizer.get_credentials(user_id)
   if credentials.nil?
     url = authorizer.get_authorization_url(base_url: OOB_URI)
     puts 'Open the following URL in the browser and enter the ' \
-         'resulting code after authorization'
-    puts url
+         "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
       user_id: user_id, code: code, base_url: OOB_URI

--- a/drive/quickstart/quickstart.rb
+++ b/drive/quickstart/quickstart.rb
@@ -19,8 +19,8 @@ require 'fileutils'
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
 APPLICATION_NAME = 'Drive API Ruby Quickstart'.freeze
-CLIENT_SECRETS_PATH = 'client_secrets.json'.freeze
-CREDENTIALS_PATH = 'token.yaml'.freeze
+CREDENTIALS_PATH = 'credentials.json'.freeze
+TOKEN_PATH = 'token.yaml'.freeze
 SCOPE = Google::Apis::DriveV3::AUTH_DRIVE_METADATA_READONLY
 
 ##
@@ -30,8 +30,8 @@ SCOPE = Google::Apis::DriveV3::AUTH_DRIVE_METADATA_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CLIENT_SECRETS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: CREDENTIALS_PATH)
+  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
+  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
   authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
   user_id = 'default'
   credentials = authorizer.get_credentials(user_id)

--- a/gmail/quickstart/quickstart.rb
+++ b/gmail/quickstart/quickstart.rb
@@ -19,8 +19,8 @@ require 'fileutils'
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
 APPLICATION_NAME = 'Gmail API Ruby Quickstart'.freeze
-CLIENT_SECRETS_PATH = 'client_secret.json'.freeze
-CREDENTIALS_PATH = 'token.yaml'.freeze
+CREDENTIALS_PATH = 'credentials.json'.freeze
+TOKEN_PATH = 'token.yaml'.freeze
 SCOPE = Google::Apis::GmailV1::AUTH_GMAIL_READONLY
 
 ##
@@ -30,8 +30,8 @@ SCOPE = Google::Apis::GmailV1::AUTH_GMAIL_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CLIENT_SECRETS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: CREDENTIALS_PATH)
+  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
+  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
   authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
   user_id = 'default'
   credentials = authorizer.get_credentials(user_id)

--- a/people/quickstart/quickstart.rb
+++ b/people/quickstart/quickstart.rb
@@ -19,8 +19,8 @@ require 'fileutils'
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
 APPLICATION_NAME = 'Google People API Ruby Quickstart'.freeze
-CLIENT_SECRETS_PATH = 'client_secret.json'.freeze
-CREDENTIALS_PATH = 'token.yaml'.freeze
+CREDENTIALS_PATH = 'credentials.json'.freeze
+TOKEN_PATH = 'token.yaml'.freeze
 SCOPE = Google::Apis::PeopleV3::AUTH_CONTACTS_READONLY
 
 ##
@@ -30,8 +30,8 @@ SCOPE = Google::Apis::PeopleV3::AUTH_CONTACTS_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CLIENT_SECRETS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: CREDENTIALS_PATH)
+  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
+  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
   authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
   user_id = 'default'
   credentials = authorizer.get_credentials(user_id)

--- a/sheets/quickstart/quickstart.rb
+++ b/sheets/quickstart/quickstart.rb
@@ -19,8 +19,8 @@ require 'fileutils'
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
 APPLICATION_NAME = 'Google Sheets API Ruby Quickstart'.freeze
-CLIENT_SECRETS_PATH = 'client_secret.json'.freeze
-CREDENTIALS_PATH = 'token.yaml'.freeze
+CREDENTIALS_PATH = 'credentials.json'.freeze
+TOKEN_PATH = 'token.yaml'.freeze
 SCOPE = Google::Apis::SheetsV4::AUTH_SPREADSHEETS_READONLY
 
 ##
@@ -30,8 +30,8 @@ SCOPE = Google::Apis::SheetsV4::AUTH_SPREADSHEETS_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CLIENT_SECRETS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: CREDENTIALS_PATH)
+  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
+  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
   authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
   user_id = 'default'
   credentials = authorizer.get_credentials(user_id)

--- a/slides/quickstart/quickstart.rb
+++ b/slides/quickstart/quickstart.rb
@@ -19,8 +19,8 @@ require 'fileutils'
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
 APPLICATION_NAME = 'Google Slides API Ruby Quickstart'.freeze
-CLIENT_SECRETS_PATH = 'client_secret.json'.freeze
-CREDENTIALS_PATH = 'token.yaml'.freeze
+CREDENTIALS_PATH = 'credentials.json'.freeze
+TOKEN_PATH = 'token.yaml'.freeze
 SCOPE = Google::Apis::SlidesV1::AUTH_PRESENTATIONS_READONLY
 
 ##
@@ -30,8 +30,8 @@ SCOPE = Google::Apis::SlidesV1::AUTH_PRESENTATIONS_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CLIENT_SECRETS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: CREDENTIALS_PATH)
+  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
+  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
   authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
   user_id = 'default'
   credentials = authorizer.get_credentials(user_id)

--- a/tasks/quickstart/quickstart.rb
+++ b/tasks/quickstart/quickstart.rb
@@ -19,8 +19,8 @@ require 'fileutils'
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
 APPLICATION_NAME = 'Google Tasks API Ruby Quickstart'.freeze
-CLIENT_SECRETS_PATH = 'client_secret.json'.freeze
-CREDENTIALS_PATH = 'token.yaml'.freeze
+CREDENTIALS_PATH = 'credentials.json'.freeze
+TOKEN_PATH = 'token.yaml'.freeze
 SCOPE = Google::Apis::DriveV3::AUTH_TASKS_READONLY
 
 ##
@@ -30,8 +30,8 @@ SCOPE = Google::Apis::DriveV3::AUTH_TASKS_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CLIENT_SECRETS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: CREDENTIALS_PATH)
+  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
+  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
   authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
   user_id = 'default'
   credentials = authorizer.get_credentials(user_id)


### PR DESCRIPTION
Change the file names expected for developer credentials and stored tokens to better match the name of the downloaded file.

Developer credentials: `client_secret.json` => `credentials.json`

Also:

- Updated the Drive Activity API quickstart to use local token storage.