### PR TITLE
Add Gemfile to each quickstart

### DIFF
--- a/admin_sdk/directory/Gemfile
+++ b/admin_sdk/directory/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'google-api-client', '~> 0.28.4'

--- a/admin_sdk/directory/Gemfile.lock
+++ b/admin_sdk/directory/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.28.4)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.10.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.10)
+    googleauth (0.8.0)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    httpclient (2.8.3)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    os (1.0.0)
+    public_suffix (3.0.3)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    uber (0.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-api-client (~> 0.28.4)
+
+BUNDLED WITH
+   1.16.2

--- a/admin_sdk/reports/Gemfile
+++ b/admin_sdk/reports/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'google-api-client', '~> 0.28.4'

--- a/admin_sdk/reports/Gemfile.lock
+++ b/admin_sdk/reports/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.28.4)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.10.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.10)
+    googleauth (0.8.0)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    httpclient (2.8.3)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    os (1.0.0)
+    public_suffix (3.0.3)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    uber (0.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-api-client (~> 0.28.4)
+
+BUNDLED WITH
+   1.16.2

--- a/admin_sdk/reseller/Gemfile
+++ b/admin_sdk/reseller/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'google-api-client', '~> 0.28.4'

--- a/admin_sdk/reseller/Gemfile.lock
+++ b/admin_sdk/reseller/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.28.4)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.10.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.10)
+    googleauth (0.8.0)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    httpclient (2.8.3)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    os (1.0.0)
+    public_suffix (3.0.3)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    uber (0.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-api-client (~> 0.28.4)
+
+BUNDLED WITH
+   1.16.2

--- a/apps_script/quickstart/Gemfile
+++ b/apps_script/quickstart/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'google-api-client', '~> 0.28.4'

--- a/apps_script/quickstart/Gemfile.lock
+++ b/apps_script/quickstart/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.28.4)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.10.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.10)
+    googleauth (0.8.0)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    httpclient (2.8.3)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    os (1.0.0)
+    public_suffix (3.0.3)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    uber (0.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-api-client (~> 0.28.4)
+
+BUNDLED WITH
+   1.16.2

--- a/apps_script/quickstart/README.md
+++ b/apps_script/quickstart/README.md
@@ -4,7 +4,7 @@ Complete the steps described in the [Google Apps Script Ruby Quickstart](https:/
 
 ## Install
 
-`gem install google-api-client`
+`bundle install`
 
 ## Run
 

--- a/calendar/quickstart/Gemfile
+++ b/calendar/quickstart/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'google-api-client', '~> 0.28.4'

--- a/calendar/quickstart/Gemfile.lock
+++ b/calendar/quickstart/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.28.4)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.10.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.10)
+    googleauth (0.8.0)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    httpclient (2.8.3)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    os (1.0.0)
+    public_suffix (3.0.3)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    uber (0.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-api-client (~> 0.28.4)
+
+BUNDLED WITH
+   1.16.2

--- a/calendar/quickstart/README.md
+++ b/calendar/quickstart/README.md
@@ -4,7 +4,7 @@ Complete the steps described in the [Google Calendar Ruby Quickstart](https://de
 
 ## Install
 
-`gem install google-api-client`
+`bundle install`
 
 ## Run
 

--- a/classroom/quickstart/Gemfile
+++ b/classroom/quickstart/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'google-api-client', '~> 0.28.4'

--- a/classroom/quickstart/Gemfile.lock
+++ b/classroom/quickstart/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.28.4)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.10.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.10)
+    googleauth (0.8.0)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    httpclient (2.8.3)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    os (1.0.0)
+    public_suffix (3.0.3)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    uber (0.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-api-client (~> 0.28.4)
+
+BUNDLED WITH
+   1.16.2

--- a/classroom/quickstart/README.md
+++ b/classroom/quickstart/README.md
@@ -4,7 +4,7 @@ Complete the steps described in the [Google Classroom Ruby Quickstart](https://d
 
 ## Install
 
-`gem install google-api-client`
+`bundle install`
 
 ## Run
 

--- a/drive/activity-v2/Gemfile
+++ b/drive/activity-v2/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'google-api-client', '~> 0.28.4'

--- a/drive/activity-v2/Gemfile.lock
+++ b/drive/activity-v2/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.28.4)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.10.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.10)
+    googleauth (0.8.0)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    httpclient (2.8.3)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    os (1.0.0)
+    public_suffix (3.0.3)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    uber (0.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-api-client (~> 0.28.4)
+
+BUNDLED WITH
+   1.16.2

--- a/drive/activity/Gemfile
+++ b/drive/activity/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'google-api-client', '~> 0.28.4'

--- a/drive/activity/Gemfile.lock
+++ b/drive/activity/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.28.4)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.10.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.10)
+    googleauth (0.8.0)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    httpclient (2.8.3)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    os (1.0.0)
+    public_suffix (3.0.3)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    uber (0.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-api-client (~> 0.28.4)
+
+BUNDLED WITH
+   1.16.2

--- a/drive/quickstart/Gemfile
+++ b/drive/quickstart/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'google-api-client', '~> 0.28.4'

--- a/drive/quickstart/Gemfile.lock
+++ b/drive/quickstart/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.28.4)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.10.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.10)
+    googleauth (0.8.0)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    httpclient (2.8.3)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    os (1.0.0)
+    public_suffix (3.0.3)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    uber (0.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-api-client (~> 0.28.4)
+
+BUNDLED WITH
+   1.16.2

--- a/drive/quickstart/README.md
+++ b/drive/quickstart/README.md
@@ -4,7 +4,7 @@ Complete the steps described in the [Google Drive Ruby Quickstart](https://devel
 
 ## Install
 
-`gem install google-api-client`
+`bundle install`
 
 ## Run
 

--- a/gmail/quickstart/Gemfile
+++ b/gmail/quickstart/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'google-api-client', '~> 0.28.4'

--- a/gmail/quickstart/Gemfile.lock
+++ b/gmail/quickstart/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.28.4)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.10.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.10)
+    googleauth (0.8.0)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    httpclient (2.8.3)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    os (1.0.0)
+    public_suffix (3.0.3)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    uber (0.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-api-client (~> 0.28.4)
+
+BUNDLED WITH
+   1.16.2

--- a/gmail/quickstart/README.md
+++ b/gmail/quickstart/README.md
@@ -4,7 +4,7 @@ Complete the steps described in the [Gmail Ruby Quickstart](https://developers.g
 
 ## Install
 
-`gem install google-api-client`
+`bundle install`
 
 ## Run
 

--- a/people/quickstart/Gemfile
+++ b/people/quickstart/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'google-api-client', '~> 0.28.4'

--- a/people/quickstart/Gemfile.lock
+++ b/people/quickstart/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.28.4)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.10.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.10)
+    googleauth (0.8.0)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    httpclient (2.8.3)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    os (1.0.0)
+    public_suffix (3.0.3)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    uber (0.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-api-client (~> 0.28.4)
+
+BUNDLED WITH
+   1.16.2

--- a/people/quickstart/README.md
+++ b/people/quickstart/README.md
@@ -4,7 +4,7 @@ Complete the steps described in the [Google People API Ruby Quickstart](https://
 
 ## Install
 
-`gem install google-api-client`
+`bundle install`
 
 ## Run
 

--- a/sheets/quickstart/Gemfile
+++ b/sheets/quickstart/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'google-api-client', '~> 0.28.4'

--- a/sheets/quickstart/Gemfile.lock
+++ b/sheets/quickstart/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.28.4)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.10.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.10)
+    googleauth (0.8.0)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    httpclient (2.8.3)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    os (1.0.0)
+    public_suffix (3.0.3)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    uber (0.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-api-client (~> 0.28.4)
+
+BUNDLED WITH
+   1.16.2

--- a/sheets/quickstart/README.md
+++ b/sheets/quickstart/README.md
@@ -4,7 +4,7 @@ Complete the steps described in the [Google Sheets Ruby Quickstart](https://deve
 
 ## Install
 
-`gem install google-api-client`
+`bundle install`
 
 ## Run
 

--- a/sheets/quickstart/quickstart.rb
+++ b/sheets/quickstart/quickstart.rb
@@ -62,7 +62,7 @@ range = 'Class Data!A2:E'
 response = service.get_spreadsheet_values(spreadsheet_id, range)
 puts 'Name, Major:'
 puts 'No data found.' if response.values.empty?
-response.values.each do |row|
+response.each_value do |row|
   # Print columns A and E, which correspond to indices 0 and 4.
   puts "#{row[0]}, #{row[4]}"
 end

--- a/slides/quickstart/Gemfile
+++ b/slides/quickstart/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'google-api-client', '~> 0.28.4'

--- a/slides/quickstart/Gemfile.lock
+++ b/slides/quickstart/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.28.4)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.10.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.10)
+    googleauth (0.8.0)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    httpclient (2.8.3)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    os (1.0.0)
+    public_suffix (3.0.3)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    uber (0.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-api-client (~> 0.28.4)
+
+BUNDLED WITH
+   1.16.2

--- a/slides/quickstart/README.md
+++ b/slides/quickstart/README.md
@@ -4,9 +4,8 @@ Complete the steps described in the [Google Slides Ruby Quickstart](https://deve
 
 ## Install
 
-`gem install google-api-client`
+`bundle install`
 
 ## Run
 
 `ruby quickstart.rb`
-

--- a/tasks/quickstart/Gemfile
+++ b/tasks/quickstart/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'google-api-client', '~> 0.28.4'

--- a/tasks/quickstart/Gemfile.lock
+++ b/tasks/quickstart/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.28.4)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.10.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.10)
+    googleauth (0.8.0)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    httpclient (2.8.3)
+    jwt (2.1.0)
+    memoist (0.16.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    os (1.0.0)
+    public_suffix (3.0.3)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    uber (0.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-api-client (~> 0.28.4)
+
+BUNDLED WITH
+   1.16.2


### PR DESCRIPTION
- Adds a `Gemfile` to each quickstart
- Instructs user to `bundle install` in READMEs.
- Fix rubocop lint issue.

Fixes #23