### PR TITLE
fix: Adds Google Ruby style. Fixes #25.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@
 inherit_gem:
   google-style: google-style.yml
 
+# TODO: Remove G Suite specific rules
 # G Suite Ruby Samples rules
 AllCops:
   TargetRubyVersion: 2.3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,11 @@ AllCops:
   Exclude:
   - '**/lib/**/*'
 
+# Exclude rubocop inheritance
+inherit_mode:
+  merge:
+    - Exclude
+
 Metrics/BlockLength:
   Max: 200
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,8 +2,6 @@
 inherit_gem:
   google-style: google-style.yml
 
-# TODO: Remove G Suite specific rules
-# G Suite Ruby Samples rules
 AllCops:
   TargetRubyVersion: 2.5
   Exclude:
@@ -14,56 +12,15 @@ inherit_mode:
   merge:
     - Exclude
 
+# G Suite Ruby Samples rules
 Metrics/BlockLength:
   Max: 200
 
 Metrics/ModuleLength:
   Max: 200
 
-Style/FormatString:
-  EnforcedStyle: sprintf
-
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 Style/WordArray:
   Enabled: false
 
-Metrics/AbcSize:
-  Max: 79
-
-Metrics/ClassLength:
-  Max: 220
-
-Metrics/CyclomaticComplexity:
-  Max: 10
-
-Metrics/LineLength:
-  Max: 127
-
 Metrics/MethodLength:
   Max: 43
-
-Metrics/ParameterLists:
-  Max: 6
-
-Metrics/PerceivedComplexity:
-  Max: 11
-
-Style/Documentation:
-  Enabled: false
-
-Layout/EmptyLines:
-  Enabled: false
-
-Layout/EmptyLinesAroundClassBody:
-  Enabled: false
-
-Style/DateTime:
-  Enabled: false
-
-Style/Next:
-  Enabled: false
-
-Style/RedundantSelf:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+# Google ruby rules
+inherit_gem:
+  google-style: google-style.yml
+
 # G Suite Ruby Samples rules
 AllCops:
   TargetRubyVersion: 2.3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ inherit_gem:
 # TODO: Remove G Suite specific rules
 # G Suite Ruby Samples rules
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
   Exclude:
   - '**/lib/**/*'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.3.7
   - 2.4.4
   - 2.5.1
-  - ruby-head
 before_install:
   # https://docs.travis-ci.com/user/languages/ruby/#bundler-20
   - gem update --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ rvm:
   - 2.5.1
   - ruby-head
 before_install:
+  # https://docs.travis-ci.com/user/languages/ruby/#bundler-20
+  - gem update --system
+  - gem install bundler
   - gem install rubocop google-style
 script:
   - rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ rvm:
   - 2.5.1
   - ruby-head
 before_install:
-  - gem install rubocop
+  - gem install rubocop google-style
 script:
   - rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,17 @@
+# Copyright 2019 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "https://rubygems.org"
+
+gem "google-style", "~> 0.2", groups: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,31 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.0)
+    google-style (0.3.0)
+      rubocop (~> 0.64.0)
+    jaro_winkler (1.5.2)
+    parallel (1.17.0)
+    parser (2.6.3.0)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
+    rainbow (3.0.0)
+    rubocop (0.64.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.4.0)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-style (~> 0.2)
+
+BUNDLED WITH
+   1.16.2

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A collection of samples that demonstrate how to call G Suite APIs in Ruby.
 
 ```
 gem install rubocop
-rubocop --fix
+rubocop
 ```
 
 It should not produce any errors, i.e.:
@@ -65,4 +65,10 @@ Inspecting 24 files
 ........................
 
 24 files inspected, no offenses detected
+```
+
+You can fix basic errors with:
+
+```
+rubocop --fix
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A collection of samples that demonstrate how to call G Suite APIs in Ruby.
 
 ```
 gem install rubocop
-rubocop
+rubocop --fix
 ```
 
 It should not produce any errors, i.e.:

--- a/admin_sdk/directory/Gemfile
+++ b/admin_sdk/directory/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.28.4'
+gem "google-api-client", "~> 0.28.4"

--- a/admin_sdk/directory/quickstart.rb
+++ b/admin_sdk/directory/quickstart.rb
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START admin_sdk_directory_quickstart]
-require 'google/apis/admin_directory_v1'
-require 'googleauth'
-require 'googleauth/stores/file_token_store'
-require 'fileutils'
+require "google/apis/admin_directory_v1"
+require "googleauth"
+require "googleauth/stores/file_token_store"
+require "fileutils"
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
-APPLICATION_NAME = 'Directory API Ruby Quickstart'.freeze
-CREDENTIALS_PATH = 'credentials.json'.freeze
+OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
+APPLICATION_NAME = "Directory API Ruby Quickstart".freeze
+CREDENTIALS_PATH = "credentials.json".freeze
 # The file token.yaml stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
-TOKEN_PATH = 'token.yaml'.freeze
+TOKEN_PATH = "token.yaml".freeze
 SCOPE = Google::Apis::AdminDirectoryV1::AUTH_ADMIN_DIRECTORY_USER_READONLY
 
 ##
@@ -33,14 +33,14 @@ SCOPE = Google::Apis::AdminDirectoryV1::AUTH_ADMIN_DIRECTORY_USER_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
-  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
-  user_id = 'default'
-  credentials = authorizer.get_credentials(user_id)
+  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
+  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
+  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
+  user_id = "default"
+  credentials = authorizer.get_credentials user_id
   if credentials.nil?
-    url = authorizer.get_authorization_url(base_url: OOB_URI)
-    puts 'Open the following URL in the browser and enter the ' \
+    url = authorizer.get_authorization_url base_url: OOB_URI
+    puts "Open the following URL in the browser and enter the " \
          "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
@@ -56,10 +56,10 @@ service = Google::Apis::AdminDirectoryV1::DirectoryService.new
 service.client_options.application_name = APPLICATION_NAME
 service.authorization = authorize
 # List the first 10 users in the domain
-response = service.list_users(customer:    'my_customer',
+response = service.list_users(customer:    "my_customer",
                               max_results: 10,
-                              order_by:    'email')
-puts 'Users:'
-puts 'No users found' if response.users.empty?
+                              order_by:    "email")
+puts "Users:"
+puts "No users found" if response.users.empty?
 response.users.each { |user| puts "- #{user.primary_email} (#{user.name.full_name})" }
 # [END admin_sdk_directory_quickstart]

--- a/admin_sdk/directory/quickstart.rb
+++ b/admin_sdk/directory/quickstart.rb
@@ -56,9 +56,9 @@ service = Google::Apis::AdminDirectoryV1::DirectoryService.new
 service.client_options.application_name = APPLICATION_NAME
 service.authorization = authorize
 # List the first 10 users in the domain
-response = service.list_users(customer: 'my_customer',
+response = service.list_users(customer:    'my_customer',
                               max_results: 10,
-                              order_by: 'email')
+                              order_by:    'email')
 puts 'Users:'
 puts 'No users found' if response.users.empty?
 response.users.each { |user| puts "- #{user.primary_email} (#{user.name.full_name})" }

--- a/admin_sdk/reports/Gemfile
+++ b/admin_sdk/reports/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.28.4'
+gem "google-api-client", "~> 0.28.4"

--- a/admin_sdk/reports/quickstart.rb
+++ b/admin_sdk/reports/quickstart.rb
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START admin_sdk_reports_quickstart]
-require 'google/apis/admin_reports_v1'
-require 'googleauth'
-require 'googleauth/stores/file_token_store'
-require 'fileutils'
+require "google/apis/admin_reports_v1"
+require "googleauth"
+require "googleauth/stores/file_token_store"
+require "fileutils"
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
-APPLICATION_NAME = 'Reports API Ruby Quickstart'.freeze
-CREDENTIALS_PATH = 'credentials.json'.freeze
+OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
+APPLICATION_NAME = "Reports API Ruby Quickstart".freeze
+CREDENTIALS_PATH = "credentials.json".freeze
 # The file token.yaml stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
-TOKEN_PATH = 'token.yaml'.freeze
+TOKEN_PATH = "token.yaml".freeze
 SCOPE = Google::Apis::AdminReportsV1::AUTH_ADMIN_REPORTS_AUDIT_READONLY
 
 ##
@@ -33,14 +33,14 @@ SCOPE = Google::Apis::AdminReportsV1::AUTH_ADMIN_REPORTS_AUDIT_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
-  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
-  user_id = 'default'
-  credentials = authorizer.get_credentials(user_id)
+  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
+  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
+  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
+  user_id = "default"
+  credentials = authorizer.get_credentials user_id
   if credentials.nil?
-    url = authorizer.get_authorization_url(base_url: OOB_URI)
-    puts 'Open the following URL in the browser and enter the ' \
+    url = authorizer.get_authorization_url base_url: OOB_URI
+    puts "Open the following URL in the browser and enter the " \
          "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
@@ -56,12 +56,12 @@ service.client_options.application_name = APPLICATION_NAME
 service.authorization = authorize
 
 # Print the last 10 login events.
-user = 'all'
-application = 'login'
-response = service.list_activities(user, application, max_results: 10)
+user = "all"
+application = "login"
+response = service.list_activities user, application, max_results: 10
 
-puts 'Logins:'
-puts 'No results found' if response.items.empty?
+puts "Logins:"
+puts "No results found" if response.items.empty?
 response.items.each do |activity|
   puts "- #{activity.id.time}: #{activity.actor.email} (#{activity.events.first.name})"
 end

--- a/admin_sdk/reseller/Gemfile
+++ b/admin_sdk/reseller/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.28.4'
+gem "google-api-client", "~> 0.28.4"

--- a/admin_sdk/reseller/quickstart.rb
+++ b/admin_sdk/reseller/quickstart.rb
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START admin_sdk_reseller_quickstart]
-require 'google/apis/reseller_v1'
-require 'googleauth'
-require 'googleauth/stores/file_token_store'
-require 'fileutils'
+require "google/apis/reseller_v1"
+require "googleauth"
+require "googleauth/stores/file_token_store"
+require "fileutils"
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
-APPLICATION_NAME = 'Reseller API Ruby Quickstart'.freeze
-CREDENTIALS_PATH = 'credentials.json'.freeze
+OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
+APPLICATION_NAME = "Reseller API Ruby Quickstart".freeze
+CREDENTIALS_PATH = "credentials.json".freeze
 # The file token.yaml stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
-TOKEN_PATH = 'token.yaml'.freeze
+TOKEN_PATH = "token.yaml".freeze
 SCOPE = Google::Apis::ResellerV1::AUTH_APPS_ORDER
 
 ##
@@ -33,14 +33,14 @@ SCOPE = Google::Apis::ResellerV1::AUTH_APPS_ORDER
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
-  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
-  user_id = 'default'
-  credentials = authorizer.get_credentials(user_id)
+  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
+  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
+  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
+  user_id = "default"
+  credentials = authorizer.get_credentials user_id
   if credentials.nil?
-    url = authorizer.get_authorization_url(base_url: OOB_URI)
-    puts 'Open the following URL in the browser and enter the ' \
+    url = authorizer.get_authorization_url base_url: OOB_URI
+    puts "Open the following URL in the browser and enter the " \
          "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
@@ -56,10 +56,10 @@ service.client_options.application_name = APPLICATION_NAME
 service.authorization = authorize
 
 # Print the first 10 subscriptions you manage.
-response = service.list_subscriptions(max_results: 10)
+response = service.list_subscriptions max_results: 10
 
-puts 'Subscriptions:'
-puts 'No subscriptions found' if response.subscriptions.empty?
+puts "Subscriptions:"
+puts "No subscriptions found" if response.subscriptions.empty?
 response.subscriptions.each do |subscription|
   puts "- #{subscription.customer_id} (#{subscription.sku_id}, #{subscription.plan.plan_name})"
 end

--- a/apps_script/execute/execute.rb
+++ b/apps_script/execute/execute.rb
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START apps_script_api_execute]
-SCRIPT_ID = 'ENTER_YOUR_SCRIPT_ID_HERE'.freeze
+SCRIPT_ID = "ENTER_YOUR_SCRIPT_ID_HERE".freeze
 
 # Create an execution request object.
 request = Google::Apis::ScriptV1::ExecutionRequest.new(
-  function: 'getFoldersUnderRoot'
+  function: "getFoldersUnderRoot"
 )
 
 begin
   # Make the API request.
-  resp = service.run_script(SCRIPT_ID, request)
+  resp = service.run_script SCRIPT_ID, request
 
   if resp.error
     # The API executed, but the script returned an error.
@@ -33,10 +33,10 @@ begin
 
     puts "Script error message: #{error['errorMessage']}"
 
-    if error['scriptStackTraceElements']
+    if error["scriptStackTraceElements"]
       # There may not be a stacktrace if the script didn't start executing.
-      puts 'Script error stacktrace:'
-      error['scriptStackTraceElements'].each do |trace|
+      puts "Script error stacktrace:"
+      error["scriptStackTraceElements"].each do |trace|
         puts "\t#{trace['function']}: #{trace['lineNumber']}"
       end
     end
@@ -44,11 +44,11 @@ begin
     # The structure of the result will depend upon what the Apps Script function
     # returns. Here, the function returns an Apps Script Object with String keys
     # and values, and so the result is treated as a Ruby hash (folderSet).
-    folder_set = resp.response['result']
+    folder_set = resp.response["result"]
     if folder_set.empty?
-      puts 'No folders returned!'
+      puts "No folders returned!"
     else
-      puts 'Folders under your root folder:'
+      puts "Folders under your root folder:"
       folder_set.each do |id, folder|
         puts "\t#{folder} (#{id})"
       end
@@ -56,6 +56,6 @@ begin
   end
 rescue Google::Apis::ClientError
   # The API encountered a problem before the script started executing.
-  puts 'Error calling API!'
+  puts "Error calling API!"
 end
 # [END apps_script_api_execute]

--- a/apps_script/quickstart/Gemfile
+++ b/apps_script/quickstart/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.28.4'
+gem "google-api-client", "~> 0.28.4"

--- a/apps_script/quickstart/quickstart.rb
+++ b/apps_script/quickstart/quickstart.rb
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START apps_script_api_quickstart]
-require 'google/apis/script_v1'
-require 'googleauth'
-require 'googleauth/stores/file_token_store'
-require 'fileutils'
+require "google/apis/script_v1"
+require "googleauth"
+require "googleauth/stores/file_token_store"
+require "fileutils"
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
-APPLICATION_NAME = 'Google Apps Script API Ruby Quickstart'.freeze
-CREDENTIALS_PATH = 'credentials.json'.freeze
+OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
+APPLICATION_NAME = "Google Apps Script API Ruby Quickstart".freeze
+CREDENTIALS_PATH = "credentials.json".freeze
 # The file token.yaml stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
-TOKEN_PATH = 'token.yaml'.freeze
-SCOPE = 'https://www.googleapis.com/auth/script.projects'.freeze
+TOKEN_PATH = "token.yaml".freeze
+SCOPE = "https://www.googleapis.com/auth/script.projects".freeze
 
 ##
 # Ensure valid credentials, either by restoring from the saved credentials
@@ -33,14 +33,14 @@ SCOPE = 'https://www.googleapis.com/auth/script.projects'.freeze
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
-  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
-  user_id = 'default'
-  credentials = authorizer.get_credentials(user_id)
+  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
+  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
+  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
+  user_id = "default"
+  credentials = authorizer.get_credentials user_id
   if credentials.nil?
-    url = authorizer.get_authorization_url(base_url: OOB_URI)
-    puts 'Open the following URL in the browser and enter the ' \
+    url = authorizer.get_authorization_url base_url: OOB_URI
+    puts "Open the following URL in the browser and enter the " \
          "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
@@ -57,27 +57,27 @@ service.authorization = authorize
 
 # Make the API request.
 request = Google::Apis::ScriptV1::CreateProjectRequest.new(
-  title: 'My Script'
+  title: "My Script"
 )
-resp = service.create_project(request)
+resp = service.create_project request
 
 script_id = resp.script_id
 content = Google::Apis::ScriptV1::Content.new(
   files:     [
     Google::Apis::ScriptV1::File.new(
-      name:   'hello',
-      type:   'SERVER_JS',
-      source: "function helloWorld() {\n  console.log('Hello, world!');\n}"
+      name:   "hello",
+      type:   "SERVER_JS",
+      source: "function helloWorld() {\n  console.log('Hello, world!'');\n}"
     ),
     Google::Apis::ScriptV1::File.new(
-      name:   'appsscript',
-      type:   'JSON',
+      name:   "appsscript",
+      type:   "JSON",
       source: "{\"timeZone\":\"America/New_York\",\"exceptionLogging\": \
         \"CLOUD\"}"
     )
   ],
   script_id: script_id
 )
-service.update_project_content(script_id, content)
+service.update_project_content script_id, content
 puts "https://script.google.com/d/#{script_id}/edit"
 # [END apps_script_api_quickstart]

--- a/apps_script/quickstart/quickstart.rb
+++ b/apps_script/quickstart/quickstart.rb
@@ -63,15 +63,15 @@ resp = service.create_project(request)
 
 script_id = resp.script_id
 content = Google::Apis::ScriptV1::Content.new(
-  files: [
+  files:     [
     Google::Apis::ScriptV1::File.new(
-      name: 'hello',
-      type: 'SERVER_JS',
+      name:   'hello',
+      type:   'SERVER_JS',
       source: "function helloWorld() {\n  console.log('Hello, world!');\n}"
     ),
     Google::Apis::ScriptV1::File.new(
-      name: 'appsscript',
-      type: 'JSON',
+      name:   'appsscript',
+      type:   'JSON',
       source: "{\"timeZone\":\"America/New_York\",\"exceptionLogging\": \
         \"CLOUD\"}"
     )

--- a/calendar/quickstart/Gemfile
+++ b/calendar/quickstart/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.28.4'
+gem "google-api-client", "~> 0.28.4"

--- a/calendar/quickstart/quickstart.rb
+++ b/calendar/quickstart/quickstart.rb
@@ -59,10 +59,10 @@ service.authorization = authorize
 # Fetch the next 10 events for the user
 calendar_id = 'primary'
 response = service.list_events(calendar_id,
-                               max_results: 10,
+                               max_results:   10,
                                single_events: true,
-                               order_by: 'startTime',
-                               time_min: DateTime.now.rfc3339)
+                               order_by:      'startTime',
+                               time_min:      DateTime.now.rfc3339)
 puts 'Upcoming events:'
 puts 'No upcoming events found' if response.items.empty?
 response.items.each do |event|

--- a/calendar/quickstart/quickstart.rb
+++ b/calendar/quickstart/quickstart.rb
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START calendar_quickstart]
-require 'google/apis/calendar_v3'
-require 'googleauth'
-require 'googleauth/stores/file_token_store'
-require 'date'
-require 'fileutils'
+require "google/apis/calendar_v3"
+require "googleauth"
+require "googleauth/stores/file_token_store"
+require "date"
+require "fileutils"
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
-APPLICATION_NAME = 'Google Calendar API Ruby Quickstart'.freeze
-CREDENTIALS_PATH = 'credentials.json'.freeze
+OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
+APPLICATION_NAME = "Google Calendar API Ruby Quickstart".freeze
+CREDENTIALS_PATH = "credentials.json".freeze
 # The file token.yaml stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
-TOKEN_PATH = 'token.yaml'.freeze
+TOKEN_PATH = "token.yaml".freeze
 SCOPE = Google::Apis::CalendarV3::AUTH_CALENDAR_READONLY
 
 ##
@@ -34,14 +34,14 @@ SCOPE = Google::Apis::CalendarV3::AUTH_CALENDAR_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
-  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
-  user_id = 'default'
-  credentials = authorizer.get_credentials(user_id)
+  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
+  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
+  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
+  user_id = "default"
+  credentials = authorizer.get_credentials user_id
   if credentials.nil?
-    url = authorizer.get_authorization_url(base_url: OOB_URI)
-    puts 'Open the following URL in the browser and enter the ' \
+    url = authorizer.get_authorization_url base_url: OOB_URI
+    puts "Open the following URL in the browser and enter the " \
          "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
@@ -57,14 +57,14 @@ service.client_options.application_name = APPLICATION_NAME
 service.authorization = authorize
 
 # Fetch the next 10 events for the user
-calendar_id = 'primary'
+calendar_id = "primary"
 response = service.list_events(calendar_id,
                                max_results:   10,
                                single_events: true,
-                               order_by:      'startTime',
+                               order_by:      "startTime",
                                time_min:      DateTime.now.rfc3339)
-puts 'Upcoming events:'
-puts 'No upcoming events found' if response.items.empty?
+puts "Upcoming events:"
+puts "No upcoming events found" if response.items.empty?
 response.items.each do |event|
   start = event.start.date || event.start.date_time
   puts "- #{event.summary} (#{start})"

--- a/classroom/quickstart/Gemfile
+++ b/classroom/quickstart/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.28.4'
+gem "google-api-client", "~> 0.28.4"

--- a/classroom/quickstart/quickstart.rb
+++ b/classroom/quickstart/quickstart.rb
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START classroom_quickstart]
-require 'google/apis/classroom_v1'
-require 'googleauth'
-require 'googleauth/stores/file_token_store'
-require 'fileutils'
+require "google/apis/classroom_v1"
+require "googleauth"
+require "googleauth/stores/file_token_store"
+require "fileutils"
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
-APPLICATION_NAME = 'Classroom API Ruby Quickstart'.freeze
-CREDENTIALS_PATH = 'credentials.json'.freeze
+OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
+APPLICATION_NAME = "Classroom API Ruby Quickstart".freeze
+CREDENTIALS_PATH = "credentials.json".freeze
 # The file token.yaml stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
-TOKEN_PATH = 'token.yaml'.freeze
+TOKEN_PATH = "token.yaml".freeze
 SCOPE = Google::Apis::ClassroomV1::AUTH_CLASSROOM_COURSES_READONLY
 
 ##
@@ -33,14 +33,14 @@ SCOPE = Google::Apis::ClassroomV1::AUTH_CLASSROOM_COURSES_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
-  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
-  user_id = 'default'
-  credentials = authorizer.get_credentials(user_id)
+  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
+  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
+  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
+  user_id = "default"
+  credentials = authorizer.get_credentials user_id
   if credentials.nil?
-    url = authorizer.get_authorization_url(base_url: OOB_URI)
-    puts 'Open the following URL in the browser and enter the ' \
+    url = authorizer.get_authorization_url base_url: OOB_URI
+    puts "Open the following URL in the browser and enter the " \
          "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
@@ -56,10 +56,10 @@ service.client_options.application_name = APPLICATION_NAME
 service.authorization = authorize
 
 # List the first 10 courses the user has access to.
-response = service.list_courses(page_size: 10)
+response = service.list_courses page_size: 10
 
-puts 'Courses:'
-puts 'No courses found' if response.courses.empty?
+puts "Courses:"
+puts "No courses found" if response.courses.empty?
 response.courses.each do |course|
   puts "- #{course.name} (#{course.id})"
 end

--- a/docs/quickstart/Gemfile
+++ b/docs/quickstart/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.28.4'
+gem "google-api-client", "~> 0.28.4"

--- a/docs/quickstart/quickstart.rb
+++ b/docs/quickstart/quickstart.rb
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START docs_quickstart]
-require 'google/apis/docs_v1'
-require 'googleauth'
-require 'googleauth/stores/file_token_store'
-require 'fileutils'
+require "google/apis/docs_v1"
+require "googleauth"
+require "googleauth/stores/file_token_store"
+require "fileutils"
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
-APPLICATION_NAME = 'Google Docs API Ruby Quickstart'.freeze
-CREDENTIALS_PATH = 'credentials.json'.freeze
+OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
+APPLICATION_NAME = "Google Docs API Ruby Quickstart".freeze
+CREDENTIALS_PATH = "credentials.json".freeze
 # The file token.yaml stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
-TOKEN_PATH = 'token.yaml'.freeze
+TOKEN_PATH = "token.yaml".freeze
 SCOPE = Google::Apis::DocsV1::AUTH_DOCUMENTS_READONLY
 
 ##
@@ -33,14 +33,14 @@ SCOPE = Google::Apis::DocsV1::AUTH_DOCUMENTS_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
-  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
-  user_id = 'default'
-  credentials = authorizer.get_credentials(user_id)
+  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
+  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
+  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
+  user_id = "default"
+  credentials = authorizer.get_credentials user_id
   if credentials.nil?
-    url = authorizer.get_authorization_url(base_url: OOB_URI)
-    puts 'Open the following URL in the browser and enter the ' \
+    url = authorizer.get_authorization_url base_url: OOB_URI
+    puts "Open the following URL in the browser and enter the " \
          "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
@@ -57,7 +57,7 @@ service.authorization = authorize
 
 # Prints the title of the sample doc:
 # https://docs.google.com/document/d/195j9eDD3ccgjQRttHhJPymLJUCOUjs-jmwTrekvdjFE/edit
-document_id = '195j9eDD3ccgjQRttHhJPymLJUCOUjs-jmwTrekvdjFE'
-document = service.get_document(document_id)
+document_id = "195j9eDD3ccgjQRttHhJPymLJUCOUjs-jmwTrekvdjFE"
+document = service.get_document document_id
 puts "The title of the document is: #{document.title}."
 # [END docs_quickstart]

--- a/drive/activity-v2/Gemfile
+++ b/drive/activity-v2/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.29.0'
+gem "google-api-client", "~> 0.29.0"

--- a/drive/activity-v2/quickstart.rb
+++ b/drive/activity-v2/quickstart.rb
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START drive_activity_v2_quickstart]
-require 'google/apis/driveactivity_v2'
-require 'googleauth'
-require 'googleauth/stores/file_token_store'
-require 'fileutils'
+require "google/apis/driveactivity_v2"
+require "googleauth"
+require "googleauth/stores/file_token_store"
+require "fileutils"
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
-APPLICATION_NAME = 'Drive Activity API Ruby Quickstart'.freeze
-CREDENTIALS_PATH = 'credentials.json'.freeze
+OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
+APPLICATION_NAME = "Drive Activity API Ruby Quickstart".freeze
+CREDENTIALS_PATH = "credentials.json".freeze
 # The file token.yaml stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
-TOKEN_PATH = 'token.yaml'.freeze
+TOKEN_PATH = "token.yaml".freeze
 SCOPE = Google::Apis::DriveactivityV2::AUTH_DRIVE_ACTIVITY_READONLY
 
 ##
@@ -33,14 +33,14 @@ SCOPE = Google::Apis::DriveactivityV2::AUTH_DRIVE_ACTIVITY_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
-  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
-  user_id = 'default'
-  credentials = authorizer.get_credentials(user_id)
+  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
+  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
+  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
+  user_id = "default"
+  credentials = authorizer.get_credentials user_id
   if credentials.nil?
-    url = authorizer.get_authorization_url(base_url: OOB_URI)
-    puts 'Open the following URL in the browser and enter the ' \
+    url = authorizer.get_authorization_url base_url: OOB_URI
+    puts "Open the following URL in the browser and enter the " \
          "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
@@ -51,79 +51,79 @@ def authorize
 end
 
 # Returns a string representation of the first elements in a list.
-def truncated(array, limit = 2)
-  contents = array[0...limit].join(', ')
-  more = array.length <= limit ? '' : ', ...'
+def truncated array, limit = 2
+  contents = array[0...limit].join ", "
+  more = array.length <= limit ? "" : ", ..."
   "[#{contents}#{more}]"
 end
 
 # Returns the name of a set property in an object, or else "unknown".
-def get_one_of(obj)
+def get_one_of obj
   obj.instance_variables.each do |var|
     return var[/^@?(.*)/, 1]
   end
-  'unknown'
+  "unknown"
 end
 
 # Returns a time associated with an activity.
-def get_time_info(activity)
+def get_time_info activity
   return activity.timestamp unless activity.timestamp.nil?
   return activity.time_range.end_time unless activity.time_range.nil?
 
-  'unknown'
+  "unknown"
 end
 
 # Returns the type of action.
-def get_action_info(action_detail)
-  get_one_of(action_detail)
+def get_action_info action_detail
+  get_one_of action_detail
 end
 
 # Returns user information, or the type of user if not a known user.
-def get_user_info(user)
+def get_user_info user
   unless user.known_user.nil?
     known_user = user.known_user
     is_me = known_user.is_current_user || false
-    return is_me ? 'people/me' : known_user.person_name
+    return is_me ? "people/me" : known_user.person_name
   end
-  get_one_of(user)
+  get_one_of user
 end
 
 # Returns actor information, or the type of actor if not a user.
-def get_actor_info(actor)
-  return get_user_info(actor.user) unless actor.user.nil?
+def get_actor_info actor
+  return get_user_info actor.user unless actor.user.nil?
 
-  get_one_of(actor)
+  get_one_of actor
 end
 
 # Returns the type of a target and an associated title.
-def get_target_info(target)
+def get_target_info target
   if !target.drive_item.nil?
-    title = target.drive_item.title || 'unknown'
+    title = target.drive_item.title || "unknown"
     return %(driveItem:"#{title}")
   elsif !target.drive.nil?
-    title = target.drive.title || 'unknown'
+    title = target.drive.title || "unknown"
     return %(drive:"#{title}")
   elsif !target.file_comment.nil?
     parent = target.file_comment.parent
-    title = parent.nil? ? 'unknown' : (parent.title || 'unknown')
+    title = parent.nil? ? "unknown" : (parent.title || "unknown")
     return %(fileComment:"#{title}")
   end
-  "#{get_one_of(target)}:unknown"
+  "#{get_one_of target}:unknown"
 end
 
 # Initialize the API
 service = Google::Apis::DriveactivityV2::DriveActivityService.new
 service.client_options.application_name = APPLICATION_NAME
 service.authorization = authorize
-request = Google::Apis::DriveactivityV2::QueryDriveActivityRequest.new(page_size: 10)
-response = service.query_drive_activity(request)
-puts 'Recent activity:'
-puts 'No activity.' if response.activities.empty?
+request = Google::Apis::DriveactivityV2::QueryDriveActivityRequest.new page_size: 10
+response = service.query_drive_activity request
+puts "Recent activity:"
+puts "No activity." if response.activities.empty?
 response.activities.each do |activity|
-  time = get_time_info(activity)
-  action = get_action_info(activity.primary_action_detail)
-  actors = activity.actors.map { |actor| get_actor_info(actor) }
-  targets = activity.targets.map { |target| get_target_info(target) }
-  puts "#{time}: #{truncated(actors)}, #{action}, #{truncated(targets)}"
+  time = get_time_info activity
+  action = get_action_info activity.primary_action_detail
+  actors = activity.actors.map { |actor| get_actor_info actor }
+  targets = activity.targets.map { |target| get_target_info target }
+  puts "#{time}: #{truncated actors}, #{action}, #{truncated targets}"
 end
 # [END drive_activity_v2_quickstart]

--- a/drive/activity/Gemfile
+++ b/drive/activity/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.28.4'
+gem "google-api-client", "~> 0.28.4"

--- a/drive/activity/quickstart.rb
+++ b/drive/activity/quickstart.rb
@@ -54,9 +54,9 @@ end
 service = Google::Apis::AppsactivityV1::AppsactivityService.new
 service.client_options.application_name = APPLICATION_NAME
 service.authorization = authorize
-response = service.list_activities(source: 'drive.google.com',
+response = service.list_activities(source:            'drive.google.com',
                                    drive_ancestor_id: 'root',
-                                   page_size: 10)
+                                   page_size:         10)
 puts 'Recent activity:'
 puts 'No resent activity' if response.activities.empty?
 response.activities.each do |activity|

--- a/drive/activity/quickstart.rb
+++ b/drive/activity/quickstart.rb
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START drive_activity_quickstart]
-require 'google/apis/appsactivity_v1'
-require 'googleauth'
-require 'googleauth/stores/file_token_store'
-require 'fileutils'
+require "google/apis/appsactivity_v1"
+require "googleauth"
+require "googleauth/stores/file_token_store"
+require "fileutils"
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
-APPLICATION_NAME = 'Drive Activity API Ruby Quickstart'.freeze
-CREDENTIALS_PATH = 'credentials.json'.freeze
+OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
+APPLICATION_NAME = "Drive Activity API Ruby Quickstart".freeze
+CREDENTIALS_PATH = "credentials.json".freeze
 # The file token.yaml stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
-TOKEN_PATH = 'token.yaml'.freeze
+TOKEN_PATH = "token.yaml".freeze
 SCOPE = Google::Apis::AppsactivityV1::AUTH_ACTIVITY
 
 ##
@@ -33,14 +33,14 @@ SCOPE = Google::Apis::AppsactivityV1::AUTH_ACTIVITY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
-  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
-  user_id = 'default'
-  credentials = authorizer.get_credentials(user_id)
+  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
+  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
+  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
+  user_id = "default"
+  credentials = authorizer.get_credentials user_id
   if credentials.nil?
-    url = authorizer.get_authorization_url(base_url: OOB_URI)
-    puts 'Open the following URL in the browser and enter the ' \
+    url = authorizer.get_authorization_url base_url: OOB_URI
+    puts "Open the following URL in the browser and enter the " \
          "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
@@ -54,18 +54,18 @@ end
 service = Google::Apis::AppsactivityV1::AppsactivityService.new
 service.client_options.application_name = APPLICATION_NAME
 service.authorization = authorize
-response = service.list_activities(source:            'drive.google.com',
-                                   drive_ancestor_id: 'root',
+response = service.list_activities(source:            "drive.google.com",
+                                   drive_ancestor_id: "root",
                                    page_size:         10)
-puts 'Recent activity:'
-puts 'No resent activity' if response.activities.empty?
+puts "Recent activity:"
+puts "No resent activity" if response.activities.empty?
 response.activities.each do |activity|
   event = activity.combined_event
   user = event.user
   target = event.target
   next if user.nil? || target.nil?
 
-  time = Time.at(event.event_time_millis.to_i / 1000)
+  time = Time.at event.event_time_millis.to_i / 1000
   puts "#{time}: #{user.name} #{event.primary_event_type} #{target.name} #{target.mime_type}"
 end
 # [END drive_activity_quickstart]

--- a/drive/quickstart/Gemfile
+++ b/drive/quickstart/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.28.4'
+gem "google-api-client", "~> 0.28.4"

--- a/drive/quickstart/quickstart.rb
+++ b/drive/quickstart/quickstart.rb
@@ -57,7 +57,7 @@ drive_service.authorization = authorize
 
 # List the 10 most recently modified files.
 response = drive_service.list_files(page_size: 10,
-                                    fields: 'nextPageToken, files(id, name)')
+                                    fields:    'nextPageToken, files(id, name)')
 puts 'Files:'
 puts 'No files found' if response.files.empty?
 response.files.each do |file|

--- a/drive/quickstart/quickstart.rb
+++ b/drive/quickstart/quickstart.rb
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START drive_quickstart]
-require 'google/apis/drive_v3'
-require 'googleauth'
-require 'googleauth/stores/file_token_store'
-require 'fileutils'
+require "google/apis/drive_v3"
+require "googleauth"
+require "googleauth/stores/file_token_store"
+require "fileutils"
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
-APPLICATION_NAME = 'Drive API Ruby Quickstart'.freeze
-CREDENTIALS_PATH = 'credentials.json'.freeze
+OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
+APPLICATION_NAME = "Drive API Ruby Quickstart".freeze
+CREDENTIALS_PATH = "credentials.json".freeze
 # The file token.yaml stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
-TOKEN_PATH = 'token.yaml'.freeze
+TOKEN_PATH = "token.yaml".freeze
 SCOPE = Google::Apis::DriveV3::AUTH_DRIVE_METADATA_READONLY
 
 ##
@@ -33,14 +33,14 @@ SCOPE = Google::Apis::DriveV3::AUTH_DRIVE_METADATA_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
-  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
-  user_id = 'default'
-  credentials = authorizer.get_credentials(user_id)
+  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
+  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
+  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
+  user_id = "default"
+  credentials = authorizer.get_credentials user_id
   if credentials.nil?
-    url = authorizer.get_authorization_url(base_url: OOB_URI)
-    puts 'Open the following URL in the browser and enter the ' \
+    url = authorizer.get_authorization_url base_url: OOB_URI
+    puts "Open the following URL in the browser and enter the " \
          "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
@@ -57,9 +57,9 @@ drive_service.authorization = authorize
 
 # List the 10 most recently modified files.
 response = drive_service.list_files(page_size: 10,
-                                    fields:    'nextPageToken, files(id, name)')
-puts 'Files:'
-puts 'No files found' if response.files.empty?
+                                    fields:    "nextPageToken, files(id, name)")
+puts "Files:"
+puts "No files found" if response.files.empty?
 response.files.each do |file|
   puts "#{file.name} (#{file.id})"
 end

--- a/drive/snippets/Gemfile
+++ b/drive/snippets/Gemfile
@@ -1,6 +1,6 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'activesupport', '>= 4.2', '< 5.1'
-gem 'google-api-client', '~> 0.11'
-gem 'rspec', '~> 3.0'
-gem 'thor', '~> 0.19'
+gem "activesupport", ">= 4.2", "< 5.1"
+gem "google-api-client", "~> 0.11"
+gem "rspec", "~> 3.0"
+gem "thor", "~> 0.19"

--- a/drive/snippets/lib/drive_snippets.rb
+++ b/drive/snippets/lib/drive_snippets.rb
@@ -27,12 +27,12 @@ class DriveSnippets
   def upload_basic
     # [START drive_upload_basic]
     file_metadata = {
-        name: 'photo.jpg'
+      name: 'photo.jpg'
     }
     file = drive_service.create_file(file_metadata,
-                                     fields: 'id',
+                                     fields:        'id',
                                      upload_source: 'files/photo.jpg',
-                                     content_type: 'image/jpeg')
+                                     content_type:  'image/jpeg')
     puts "File Id: #{file.id}"
     # [END drive_upload_basic]
     file.id
@@ -43,9 +43,9 @@ class DriveSnippets
     file_metadata = {}
     file = drive_service.update_file(id,
                                      file_metadata,
-                                     fields: 'id',
+                                     fields:        'id',
                                      upload_source: 'files/photo.jpg',
-                                     content_type: 'image/jpeg')
+                                     content_type:  'image/jpeg')
     puts "File Id: #{file.id}"
     # [END drive_upload_revision]
     file.id
@@ -58,13 +58,13 @@ class DriveSnippets
     folder_id = real_folder_id
     # [END_EXCLUDE]
     file_metadata = {
-        name: 'photo.jpg',
-        parents: [folder_id]
+      name:    'photo.jpg',
+      parents: [folder_id]
     }
     file = drive_service.create_file(file_metadata,
-                                     fields: 'id',
+                                     fields:        'id',
                                      upload_source: 'files/photo.jpg',
-                                     content_type: 'image/jpeg')
+                                     content_type:  'image/jpeg')
     puts "File Id: #{file.id}"
     # [END drive_upload_to_folder]
     file.id
@@ -73,13 +73,13 @@ class DriveSnippets
   def upload_with_conversion
     # [START drive_upload_with_conversion]
     file_metadata = {
-        name: 'My Report',
-        mime_type: 'application/vnd.google-apps.spreadsheet'
+      name:      'My Report',
+      mime_type: 'application/vnd.google-apps.spreadsheet'
     }
     file = drive_service.create_file(file_metadata,
-                                     fields: 'id',
+                                     fields:        'id',
                                      upload_source: 'files/report.csv',
-                                     content_type: 'text/csv')
+                                     content_type:  'text/csv')
     puts "File Id: #{file.id}"
     # [END drive_upload_with_conversion]
     return file.id
@@ -112,8 +112,8 @@ class DriveSnippets
   def create_shortcut
     # [START drive_create_shortcut]
     file_metadata = {
-        name: 'Project plan',
-        mime_type: 'application/vnd.google-apps.drive-sdk'
+      name:      'Project plan',
+      mime_type: 'application/vnd.google-apps.drive-sdk'
     }
     file = drive_service.create_file(file_metadata, fields: 'id')
     puts "File Id: #{file.id}"
@@ -125,7 +125,7 @@ class DriveSnippets
     # [START drive_touch_file]
     file_id = '1sTWaJ_j7PkjzaBWtNc3IzovK5hQf21FbOw9yLeeLPNQ';
     file_metadata = {
-        modified_time: DateTime.now
+      modified_time: DateTime.now
     }
     # [START_EXCLUDE silent]
     file_id = real_file_id
@@ -142,8 +142,8 @@ class DriveSnippets
   def create_folder
     # [START drive_create_folder]
     file_metadata = {
-        name: 'Invoices',
-        mime_type: 'application/vnd.google-apps.folder'
+      name:      'Invoices',
+      mime_type: 'application/vnd.google-apps.folder'
     }
     file = drive_service.create_file(file_metadata, fields: 'id')
     puts "Folder Id: #{file.id}"
@@ -165,9 +165,9 @@ class DriveSnippets
     previous_parents = file.parents.join(',')
     # Move the file to the new folder
     file = drive_service.update_file(file_id,
-                                     add_parents: folder_id,
+                                     add_parents:    folder_id,
                                      remove_parents: previous_parents,
-                                     fields: 'id, parents')
+                                     fields:         'id, parents')
     # [END drive_move_file_to_folder]
     return file.parents
   end
@@ -175,9 +175,9 @@ class DriveSnippets
   def search_files
     # [START drive_search_files]
     files = drive_service.fetch_all(items: :files) do |page_token|
-      drive_service.list_files(q: "mimeType='image/jpeg'",
-                               spaces: 'drive',
-                               fields: 'nextPageToken, files(id, name)',
+      drive_service.list_files(q:          "mimeType='image/jpeg'",
+                               spaces:     'drive',
+                               fields:     'nextPageToken, files(id, name)',
                                page_token: page_token)
     end
     for file in files
@@ -208,9 +208,9 @@ class DriveSnippets
     end
     drive_service.batch do |service|
       user_permission = {
-          type: 'user',
-          role: 'writer',
-          email_address: 'user@example.com'
+        type:          'user',
+        role:          'writer',
+        email_address: 'user@example.com'
       }
       # [START_EXCLUDE silent]
       user_permission[:email_address] = real_user
@@ -220,9 +220,9 @@ class DriveSnippets
                                 fields: 'id',
                                 &callback)
       domain_permission = {
-          type: 'domain',
-          role: 'reader',
-          domain: 'example.com'
+        type:   'domain',
+        role:   'reader',
+        domain: 'example.com'
       }
       # [START_EXCLUDE silent]
       domain_permission[:domain] = real_domain
@@ -269,13 +269,13 @@ class DriveSnippets
   def upload_app_data
     # [START drive_upload_app_data]
     file_metadata = {
-        name: 'config.json',
-        parents: ['appDataFolder']
+      name:    'config.json',
+      parents: ['appDataFolder']
     }
     file = drive_service.create_file(file_metadata,
-                                     fields: 'id',
+                                     fields:        'id',
                                      upload_source: 'files/config.json',
-                                     content_type: 'application/json')
+                                     content_type:  'application/json')
     puts "File Id: #{file.id}"
     # [END drive_upload_app_data]
     file.id
@@ -283,8 +283,8 @@ class DriveSnippets
 
   def list_app_data
     # [START drive_list_app_data]
-    response = drive_service.list_files(spaces: 'appDataFolder',
-                                        fields: 'nextPageToken, files(id, name)',
+    response = drive_service.list_files(spaces:    'appDataFolder',
+                                        fields:    'nextPageToken, files(id, name)',
                                         page_size: 10)
     for file in response.files
       # Process change
@@ -305,7 +305,7 @@ class DriveSnippets
   def create_team_drive
     # [START drive_create_team_drive]
     team_drive_metadata = {
-        name: 'Project Resources'
+      name: 'Project Resources'
     }
     request_id = SecureRandom.uuid
     team_drive = drive_service.create_teamdrive(request_id,
@@ -326,9 +326,9 @@ class DriveSnippets
     # and the associated permissions and groups to ensure an active
     # organizer is assigned.
     new_organizer_permission = {
-        type: 'user',
-        role: 'organizer',
-        email_address: 'user@example.com'
+      type:          'user',
+      role:          'organizer',
+      email_address: 'user@example.com'
     }
     # [START_EXCLUDE silent]
     new_organizer_permission[:email_address] = real_user
@@ -336,10 +336,11 @@ class DriveSnippets
 
     team_drives = drive_service.fetch_all(items: :team_drives) do |page_token|
       drive_service.list_teamdrives(
-          q: 'organizerCount = 0',
-          fields: 'nextPageToken, teamDrives(id, name)',
-          use_domain_admin_access: true,
-          page_token: page_token)
+        q:                       'organizerCount = 0',
+        fields:                  'nextPageToken, teamDrives(id, name)',
+        use_domain_admin_access: true,
+        page_token:              page_token
+      )
     end
 
     for team_drive in team_drives
@@ -347,8 +348,8 @@ class DriveSnippets
       permission = drive_service.create_permission(team_drive.id,
                                                    new_organizer_permission,
                                                    use_domain_admin_access: true,
-                                                   supports_team_drives: true,
-                                                   fields: 'id')
+                                                   supports_team_drives:    true,
+                                                   fields:                  'id')
       puts "Added organizer permission: {permission.id}"
     end
     # [END drive_recover_team_drives]

--- a/drive/snippets/lib/team_drive_snippets.rb
+++ b/drive/snippets/lib/team_drive_snippets.rb
@@ -27,7 +27,7 @@ class TeamDriveSnippets
   def create_team_drive
     # [START drive_create_team_drive]
     team_drive_metadata = {
-        name: 'Project Resources'
+      name: 'Project Resources'
     }
     request_id = SecureRandom.uuid
     team_drive = drive_service.create_teamdrive(request_id,
@@ -48,9 +48,9 @@ class TeamDriveSnippets
     # and the associated permissions and groups to ensure an active
     # organizer is assigned.
     new_organizer_permission = {
-        type: 'user',
-        role: 'organizer',
-        email_address: 'user@example.com'
+      type:          'user',
+      role:          'organizer',
+      email_address: 'user@example.com'
     }
     # [START_EXCLUDE silent]
     new_organizer_permission[:email_address] = real_user
@@ -58,10 +58,11 @@ class TeamDriveSnippets
 
     team_drives = drive_service.fetch_all(items: :team_drives) do |page_token|
       drive_service.list_teamdrives(
-          q: 'organizerCount = 0',
-          fields: 'nextPageToken, teamDrives(id, name)',
-          use_domain_admin_access: true,
-          page_token: page_token)
+        q:                       'organizerCount = 0',
+        fields:                  'nextPageToken, teamDrives(id, name)',
+        use_domain_admin_access: true,
+        page_token:              page_token
+      )
     end
 
     for team_drive in team_drives
@@ -69,8 +70,8 @@ class TeamDriveSnippets
       permission = drive_service.create_permission(team_drive.id,
                                                    new_organizer_permission,
                                                    use_domain_admin_access: true,
-                                                   supports_team_drives: true,
-                                                   fields: 'id')
+                                                   supports_team_drives:    true,
+                                                   fields:                  'id')
       puts "Added organizer permission: {permission.id}"
     end
     # [END drive_recover_team_drives]

--- a/drive/snippets/spec/drive_snippets_spec.rb
+++ b/drive/snippets/spec/drive_snippets_spec.rb
@@ -12,134 +12,134 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'spec_helper'
-require 'drive_snippets'
+require "spec_helper"
+require "drive_snippets"
 
 RSpec.describe DriveSnippets do
   include TestHelpers
 
-  before(:all) do
-    @snippets = DriveSnippets.new(build_service)
+  before :all do
+    @snippets = DriveSnippets.new build_service
     reset
   end
 
-  after(:all) do
+  after :all do
     cleanup_files
   end
 
-  it 'should upload a photo' do
+  it "should upload a photo" do
     file_id = @snippets.upload_basic
     expect(file_id).to_not be_nil
-    delete_file_on_cleanup(file_id)
+    delete_file_on_cleanup file_id
   end
 
-  it 'should upload a revision' do
+  it "should upload a revision" do
     file_id = @snippets.upload_basic
-    file_id = @snippets.upload_revision(file_id)
+    file_id = @snippets.upload_revision file_id
     expect(file_id).to_not be_nil
-    delete_file_on_cleanup(file_id)
+    delete_file_on_cleanup file_id
   end
 
-  it 'should upload to a folder' do
+  it "should upload to a folder" do
     folder_id = @snippets.create_folder
-    delete_file_on_cleanup(folder_id)
-    file_id = @snippets.upload_to_folder(folder_id)
+    delete_file_on_cleanup folder_id
+    file_id = @snippets.upload_to_folder folder_id
     expect(file_id).to_not be_nil
-    delete_file_on_cleanup(file_id)
+    delete_file_on_cleanup file_id
   end
 
-  it 'should upload and convert' do
+  it "should upload and convert" do
     file_id = @snippets.upload_with_conversion
     expect(file_id).to_not be_nil
-    delete_file_on_cleanup(file_id)
+    delete_file_on_cleanup file_id
   end
 
-  it 'should export a PDF' do
+  it "should export a PDF" do
     file_id = create_test_document
-    content = @snippets.export_pdf(file_id)
+    content = @snippets.export_pdf file_id
     content = content.string
     expect(content.length).to_not be 0
-    expect(content.slice(0, 4)).to eq '%PDF'
+    expect(content.slice(0, 4)).to eq "%PDF"
   end
 
-  it 'should download a file' do
+  it "should download a file" do
     file_id = create_test_blob
-    content = @snippets.download_file(file_id)
+    content = @snippets.download_file file_id
     content = content.string
     expect(content.length).to_not eq 0
     expect(content[0]).to eq "\xFF"
     expect(content[1]).to eq "\xD8"
   end
 
-  it 'should create a short cut' do
+  it "should create a short cut" do
     file_id = @snippets.create_shortcut
     expect(file_id).to_not be_nil
-    delete_file_on_cleanup(file_id)
+    delete_file_on_cleanup file_id
   end
 
-  it 'should update the modified time' do
+  it "should update the modified time" do
     file_id = create_test_blob
-    now = DateTime.now()
+    now = DateTime.now
     now = DateTime.new(now.year, now.month, now.day, now.hour, now.minute,
                        now.second)
-    modified_time = @snippets.touch_file(file_id, now)
+    modified_time = @snippets.touch_file file_id, now
     expect(modified_time).to eq(now)
   end
 
-  it 'should create a folder' do
+  it "should create a folder" do
     file_id = @snippets.create_folder
     expect(file_id).to_not be_nil
-    delete_file_on_cleanup(file_id)
+    delete_file_on_cleanup file_id
   end
 
-  it 'should move a file to a folder' do
+  it "should move a file to a folder" do
     folder_id = @snippets.create_folder
-    delete_file_on_cleanup(folder_id)
+    delete_file_on_cleanup folder_id
     file_id = create_test_blob
-    parents = @snippets.move_file_to_folder(file_id, folder_id)
+    parents = @snippets.move_file_to_folder file_id, folder_id
     expect(parents).to include folder_id
     expect(parents.length).to eq 1
   end
 
-  it 'should search files' do
+  it "should search files" do
     create_test_blob
     files = @snippets.search_files
     expect(files.length).to_not eq 0
   end
 
-  it 'should share files' do
+  it "should share files" do
     file_id = create_test_blob
-    ids = @snippets.share_file(file_id, 'user@test.appsdevtesting.com', 'test.appsdevtesting.com')
+    ids = @snippets.share_file file_id, "user@test.appsdevtesting.com", "test.appsdevtesting.com"
     expect(ids.length).to eq 2
   end
 
-  it 'should get the starting page token' do
+  it "should get the starting page token" do
     token = @snippets.fetch_start_page_token
     expect(token).to_not be_nil
   end
 
-  it 'should fetch changes' do
+  it "should fetch changes" do
     start_token = @snippets.fetch_start_page_token
     create_test_blob
-    token = @snippets.fetch_changes(start_token)
+    token = @snippets.fetch_changes start_token
     expect(token).to_not be_nil
     expect(token).to_not eq start_token
   end
 
-  it 'should upload a photo' do
+  it "should upload a photo" do
     file_id = @snippets.upload_app_data
     expect(file_id).to_not be_nil
-    delete_file_on_cleanup(file_id)
+    delete_file_on_cleanup file_id
   end
 
-  it 'should list files' do
+  it "should list files" do
     file_id = @snippets.upload_app_data
-    delete_file_on_cleanup(file_id)
+    delete_file_on_cleanup file_id
     files = @snippets.list_app_data
     expect(files.length).to_not eq 0
   end
 
-  it 'should fetch the app data folder' do
+  it "should fetch the app data folder" do
     file_id = @snippets.fetch_app_data_folder
     expect(file_id).to_not be_nil
   end

--- a/drive/snippets/spec/spec_helper.rb
+++ b/drive/snippets/spec/spec_helper.rb
@@ -70,19 +70,19 @@ module TestHelpers
     file_metadata = { name: 'photo.jpg' }
     file = drive_service.create_file(file_metadata,
                                      upload_source: 'files/photo.jpg',
-                                     content_type: 'image/jpeg')
+                                     content_type:  'image/jpeg')
     delete_file_on_cleanup(file.id)
     file.id
   end
 
   def create_test_document
     file_metadata = {
-      name: 'Test Document',
+      name:      'Test Document',
       mime_type: 'application/vnd.google-apps.document'
     }
     file = drive_service.create_file(file_metadata,
                                      upload_source: 'files/document.txt',
-                                     content_type: 'text/plain')
+                                     content_type:  'text/plain')
     delete_file_on_cleanup(file.id)
     file.id
   end

--- a/drive/snippets/spec/spec_helper.rb
+++ b/drive/snippets/spec/spec_helper.rb
@@ -24,6 +24,7 @@ require "rspec"
 require "googleauth"
 require "google/apis/drive_v3"
 
+# Drive Test Helpers
 module TestHelpers
   # Builds a DriveService with a service account
   def build_service

--- a/drive/snippets/spec/spec_helper.rb
+++ b/drive/snippets/spec/spec_helper.rb
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 spec_dir = __dir__
-root_dir = File.expand_path(File.join(spec_dir, '..'))
-lib_dir = File.expand_path(File.join(root_dir, 'lib'))
+root_dir = File.expand_path File.join(spec_dir, "..")
+lib_dir = File.expand_path File.join(root_dir, "lib")
 
-$LOAD_PATH.unshift(spec_dir)
-$LOAD_PATH.unshift(lib_dir)
+$LOAD_PATH.unshift spec_dir
+$LOAD_PATH.unshift lib_dir
 $LOAD_PATH.uniq!
 
-require 'rspec'
-require 'googleauth'
-require 'google/apis/drive_v3'
+require "rspec"
+require "googleauth"
+require "google/apis/drive_v3"
 
 module TestHelpers
   # Builds a DriveService with a service account
@@ -55,35 +55,35 @@ module TestHelpers
     drive_service.batch do
       @files_to_delete.each do |file_id|
         puts "Deleting file #{file_id}"
-        drive_service.delete_file(file_id) do |res, err|
+        drive_service.delete_file file_id do |res, err|
           # Ignore errors...
         end
       end
     end
   end
 
-  def delete_file_on_cleanup(file_id)
+  def delete_file_on_cleanup file_id
     @files_to_delete << file_id
   end
 
   def create_test_blob
-    file_metadata = { name: 'photo.jpg' }
+    file_metadata = { name: "photo.jpg" }
     file = drive_service.create_file(file_metadata,
-                                     upload_source: 'files/photo.jpg',
-                                     content_type:  'image/jpeg')
-    delete_file_on_cleanup(file.id)
+                                     upload_source: "files/photo.jpg",
+                                     content_type:  "image/jpeg")
+    delete_file_on_cleanup file.id
     file.id
   end
 
   def create_test_document
     file_metadata = {
-      name:      'Test Document',
-      mime_type: 'application/vnd.google-apps.document'
+      name:      "Test Document",
+      mime_type: "application/vnd.google-apps.document"
     }
     file = drive_service.create_file(file_metadata,
-                                     upload_source: 'files/document.txt',
-                                     content_type:  'text/plain')
-    delete_file_on_cleanup(file.id)
+                                     upload_source: "files/document.txt",
+                                     content_type:  "text/plain")
+    delete_file_on_cleanup file.id
     file.id
   end
 end

--- a/drive/snippets/spec/team_drive_snippets_spec.rb
+++ b/drive/snippets/spec/team_drive_snippets_spec.rb
@@ -12,30 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'spec_helper'
-require 'team_drive_snippets'
+require "spec_helper"
+require "team_drive_snippets"
 
 RSpec.describe TeamDriveSnippets do
   include TestHelpers
 
-  before(:all) do
-    @snippets = TeamDriveSnippets.new(build_oauth_service)
+  before :all do
+    @snippets = TeamDriveSnippets.new build_oauth_service
     reset
   end
 
-  after(:all) do
+  after service.run_script do
     cleanup_files
   end
 
-  # it 'should create a team drive' do
+  # it "should create a team drive" do
   #   id = @snippets.create_team_drive
   #   expect(id).to_not be_nil
   #   drive_service.delete_teamdrive(id)
   # end
 
-  # it 'should recover an orphaned team drive' do
+  # it "should recover an orphaned team drive" do
   #   id = self.create_orphaned_team_drive
-  #   team_drives = @snippets.recover_team_drives('sbazyl@test.appsdevtesting.com')
+  #   team_drives = @snippets.recover_team_drives("sbazyl@test.appsdevtesting.com")
   #   expect(team_drives.length).to_not eq 0
   #   drive_service.delete_teamdrive(id)
   # end

--- a/gmail/quickstart/Gemfile
+++ b/gmail/quickstart/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.28.4'
+gem "google-api-client", "~> 0.28.4"

--- a/gmail/quickstart/quickstart.rb
+++ b/gmail/quickstart/quickstart.rb
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START gmail_quickstart]
-require 'google/apis/gmail_v1'
-require 'googleauth'
-require 'googleauth/stores/file_token_store'
-require 'fileutils'
+require "google/apis/gmail_v1"
+require "googleauth"
+require "googleauth/stores/file_token_store"
+require "fileutils"
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
-APPLICATION_NAME = 'Gmail API Ruby Quickstart'.freeze
-CREDENTIALS_PATH = 'credentials.json'.freeze
+OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
+APPLICATION_NAME = "Gmail API Ruby Quickstart".freeze
+CREDENTIALS_PATH = "credentials.json".freeze
 # The file token.yaml stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
-TOKEN_PATH = 'token.yaml'.freeze
+TOKEN_PATH = "token.yaml".freeze
 SCOPE = Google::Apis::GmailV1::AUTH_GMAIL_READONLY
 
 ##
@@ -33,14 +33,14 @@ SCOPE = Google::Apis::GmailV1::AUTH_GMAIL_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
-  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
-  user_id = 'default'
-  credentials = authorizer.get_credentials(user_id)
+  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
+  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
+  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
+  user_id = "default"
+  credentials = authorizer.get_credentials user_id
   if credentials.nil?
-    url = authorizer.get_authorization_url(base_url: OOB_URI)
-    puts 'Open the following URL in the browser and enter the ' \
+    url = authorizer.get_authorization_url base_url: OOB_URI
+    puts "Open the following URL in the browser and enter the " \
          "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
@@ -56,9 +56,9 @@ service.client_options.application_name = APPLICATION_NAME
 service.authorization = authorize
 
 # Show the user's labels
-user_id = 'me'
-result = service.list_user_labels(user_id)
-puts 'Labels:'
-puts 'No labels found' if result.labels.empty?
+user_id = "me"
+result = service.list_user_labels user_id
+puts "Labels:"
+puts "No labels found" if result.labels.empty?
 result.labels.each { |label| puts "- #{label.name}" }
 # [END gmail_quickstart]

--- a/people/quickstart/Gemfile
+++ b/people/quickstart/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.28.4'
+gem "google-api-client", "~> 0.28.4"

--- a/people/quickstart/quickstart.rb
+++ b/people/quickstart/quickstart.rb
@@ -58,7 +58,7 @@ service.authorization = authorize
 # Fetch the next 10 events for the user
 response = service.list_person_connections(
   'people/me',
-  page_size: 10,
+  page_size:     10,
   person_fields: 'names,emailAddresses'
 )
 

--- a/people/quickstart/quickstart.rb
+++ b/people/quickstart/quickstart.rb
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START people_quickstart]
-require 'google/apis/people_v1'
-require 'googleauth'
-require 'googleauth/stores/file_token_store'
-require 'fileutils'
+require "google/apis/people_v1"
+require "googleauth"
+require "googleauth/stores/file_token_store"
+require "fileutils"
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
-APPLICATION_NAME = 'Google People API Ruby Quickstart'.freeze
-CREDENTIALS_PATH = 'credentials.json'.freeze
+OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
+APPLICATION_NAME = "Google People API Ruby Quickstart".freeze
+CREDENTIALS_PATH = "credentials.json".freeze
 # The file token.yaml stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
-TOKEN_PATH = 'token.yaml'.freeze
+TOKEN_PATH = "token.yaml".freeze
 SCOPE = Google::Apis::PeopleV1::AUTH_CONTACTS_READONLY
 
 ##
@@ -33,14 +33,14 @@ SCOPE = Google::Apis::PeopleV1::AUTH_CONTACTS_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
-  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
-  user_id = 'default'
-  credentials = authorizer.get_credentials(user_id)
+  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
+  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
+  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
+  user_id = "default"
+  credentials = authorizer.get_credentials user_id
   if credentials.nil?
-    url = authorizer.get_authorization_url(base_url: OOB_URI)
-    puts 'Open the following URL in the browser and enter the ' \
+    url = authorizer.get_authorization_url base_url: OOB_URI
+    puts "Open the following URL in the browser and enter the " \
          "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
@@ -57,17 +57,17 @@ service.authorization = authorize
 
 # Fetch the next 10 events for the user
 response = service.list_person_connections(
-  'people/me',
+  "people/me",
   page_size:     10,
-  person_fields: 'names,emailAddresses'
+  person_fields: "names,emailAddresses"
 )
 
-puts 'Connection names:'
-puts 'No connections found' if response.connections.empty?
+puts "Connection names:"
+puts "No connections found" if response.connections.empty?
 response.connections.each do |person|
   names = person.names
   if names.nil?
-    puts 'No names found for connection'
+    puts "No names found for connection"
   else
     puts "- #{names[0].display_name}"
   end

--- a/sheets/quickstart/Gemfile
+++ b/sheets/quickstart/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.28.4'
+gem "google-api-client", "~> 0.28.4"

--- a/sheets/quickstart/quickstart.rb
+++ b/sheets/quickstart/quickstart.rb
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START sheets_quickstart]
-require 'google/apis/sheets_v4'
-require 'googleauth'
-require 'googleauth/stores/file_token_store'
-require 'fileutils'
+require "google/apis/sheets_v4"
+require "googleauth"
+require "googleauth/stores/file_token_store"
+require "fileutils"
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
-APPLICATION_NAME = 'Google Sheets API Ruby Quickstart'.freeze
-CREDENTIALS_PATH = 'credentials.json'.freeze
+OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
+APPLICATION_NAME = "Google Sheets API Ruby Quickstart".freeze
+CREDENTIALS_PATH = "credentials.json".freeze
 # The file token.yaml stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
-TOKEN_PATH = 'token.yaml'.freeze
+TOKEN_PATH = "token.yaml".freeze
 SCOPE = Google::Apis::SheetsV4::AUTH_SPREADSHEETS_READONLY
 
 ##
@@ -33,14 +33,14 @@ SCOPE = Google::Apis::SheetsV4::AUTH_SPREADSHEETS_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
-  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
-  user_id = 'default'
-  credentials = authorizer.get_credentials(user_id)
+  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
+  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
+  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
+  user_id = "default"
+  credentials = authorizer.get_credentials user_id
   if credentials.nil?
-    url = authorizer.get_authorization_url(base_url: OOB_URI)
-    puts 'Open the following URL in the browser and enter the ' \
+    url = authorizer.get_authorization_url base_url: OOB_URI
+    puts "Open the following URL in the browser and enter the " \
          "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
@@ -57,11 +57,11 @@ service.authorization = authorize
 
 # Prints the names and majors of students in a sample spreadsheet:
 # https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms/edit
-spreadsheet_id = '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms'
-range = 'Class Data!A2:E'
-response = service.get_spreadsheet_values(spreadsheet_id, range)
-puts 'Name, Major:'
-puts 'No data found.' if response.values.empty?
+spreadsheet_id = "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms"
+range = "Class Data!A2:E"
+response = service.get_spreadsheet_values spreadsheet_id, range
+puts "Name, Major:"
+puts "No data found." if response.values.empty?
 response.values.each do |row|
   # Print columns A and E, which correspond to indices 0 and 4.
   puts "#{row[0]}, #{row[4]}"

--- a/sheets/snippets/Gemfile
+++ b/sheets/snippets/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~>0.11'
-gem 'rspec', '~> 3.0'
+gem "google-api-client", "~>0.11"
+gem "rspec", "~> 3.0"

--- a/sheets/snippets/lib/spreadsheet_snippets.rb
+++ b/sheets/snippets/lib/spreadsheet_snippets.rb
@@ -15,7 +15,6 @@
 require 'google/apis/sheets_v4'
 
 class SpreadsheetSnippets
-
   def initialize(service)
     @service = service
   end
@@ -44,22 +43,22 @@ class SpreadsheetSnippets
     # Change the name of sheet ID '0' (the default first sheet on every
     # spreadsheet)
     requests.push({
-      update_sheet_properties: {
-        properties: {sheet_id: 0, title: 'New Sheet Name'},
-        fields: 'title'
-      }
-    })
+                    update_sheet_properties: {
+                      properties: { sheet_id: 0, title: 'New Sheet Name' },
+                      fields:     'title'
+                    }
+                  })
     # Find and replace text
     requests.push({
-      find_replace: {
-        find: find,
-        replacement: replacement,
-        all_sheets: true
-      }
-    })
+                    find_replace: {
+                      find:        find,
+                      replacement: replacement,
+                      all_sheets:  true
+                    }
+                  })
     # Add additional requests (operations) ...
 
-    body = {requests: requests}
+    body = { requests: requests }
     result = service.batch_update_spreadsheet(spreadsheet_id, body, {})
     find_replace_response = result.replies[1].find_replace
     puts "#{find_replace_response.occurrences_changed} replacements made."
@@ -104,12 +103,12 @@ class SpreadsheetSnippets
     # [END_EXCLUDE]
     data = [
       {
-        range: range_name,
+        range:  range_name,
         values: values
       },
       # Additional ranges to update ...
     ]
-    value_range_object = Google::Apis::SheetsV4::ValueRange.new(range: range_name,
+    value_range_object = Google::Apis::SheetsV4::ValueRange.new(range:  range_name,
                                                                 values: values)
     result = service.update_spreadsheet_value(spreadsheet_id,
                                               range_name,
@@ -133,14 +132,15 @@ class SpreadsheetSnippets
     # [END_EXCLUDE]
     data = [
       {
-        range: range_name,
+        range:  range_name,
         values: values
       },
       # Additional ranges to update ...
     ]
     batch_update_values = Google::Apis::SheetsV4::BatchUpdateValuesRequest.new(
-        data: data,
-        value_input_option: value_input_option)
+      data:               data,
+      value_input_option: value_input_option
+    )
     result = service.batch_update_values(spreadsheet_id, batch_update_values)
     puts "#{result.total_updated_cells} cells updated."
     # [END sheets_batch_update_values]
@@ -185,34 +185,34 @@ class SpreadsheetSnippets
     # [START sheets_pivot_tables]
     requests = [{
       update_cells: {
-        rows: {
-           values: [
+        rows:   {
+          values: [
             {
               pivot_table: {
-                source: {
-                  sheet_id: source_sheet_id,
-                  start_row_index: 0,
+                source:       {
+                  sheet_id:           source_sheet_id,
+                  start_row_index:    0,
                   start_column_index: 0,
-                  end_row_index: 20,
-                  end_column_index: 7
+                  end_row_index:      20,
+                  end_column_index:   7
                 },
-                rows: [
+                rows:         [
                   {
                     source_column_offset: 1,
-                    show_totals: true,
-                    sort_order: 'ASCENDING',
+                    show_totals:          true,
+                    sort_order:           'ASCENDING',
                   },
                 ],
-                columns: [
+                columns:      [
                   {
                     source_column_offset: 4,
-                    sort_order: 'ASCENDING',
-                    show_totals: true,
+                    sort_order:           'ASCENDING',
+                    show_totals:          true,
                   }
                 ],
-                values: [
+                values:       [
                   {
-                    summarize_function: 'COUNTA',
+                    summarize_function:   'COUNTA',
                     source_column_offset: 4
                   }
                 ],
@@ -221,9 +221,9 @@ class SpreadsheetSnippets
             }
           ]
         },
-        start: {
-          sheet_id: target_sheet_id,
-          row_index: 0,
+        start:  {
+          sheet_id:     target_sheet_id,
+          row_index:    0,
           column_index: 0
         },
         fields: 'pivotTable'
@@ -237,23 +237,23 @@ class SpreadsheetSnippets
   def conditional_formatting(spreadsheet_id)
     # [START sheets_conditional_formatting]
     my_range = {
-      sheet_id: 0,
-      start_row_index: 1,
-      end_row_index: 11,
+      sheet_id:           0,
+      start_row_index:    1,
+      end_row_index:      11,
       start_column_index: 0,
-      end_column_index: 4
+      end_column_index:   4
     }
     requests = [{
       add_conditional_format_rule: {
-        rule: {
-          ranges: [my_range],
+        rule:  {
+          ranges:       [my_range],
           boolean_rule: {
             condition: {
-              type: 'CUSTOM_FORMULA',
+              type:   'CUSTOM_FORMULA',
               values: [{ user_entered_value: '=GT($D2,median($D$2:$D$11))' }]
             },
-            format: {
-              text_format: { foreground_color: { red: 0.8 }}
+            format:    {
+              text_format: { foreground_color: { red: 0.8 } }
             }
           }
         },
@@ -261,14 +261,14 @@ class SpreadsheetSnippets
       }
     }, {
       add_conditional_format_rule: {
-        rule: {
-          ranges: [my_range],
+        rule:  {
+          ranges:       [my_range],
           boolean_rule: {
             condition: {
-              type: 'CUSTOM_FORMULA',
+              type:   'CUSTOM_FORMULA',
               values: [{ user_entered_value: '=LT($D2,median($D$2:$D$11))' }]
             },
-            format: {
+            format:    {
               background_color: { red: 1, green: 0.4, blue: 0.4 }
             }
           }

--- a/sheets/snippets/spec/spec_helper.rb
+++ b/sheets/snippets/spec/spec_helper.rb
@@ -88,14 +88,14 @@ module TestHelpers
     body = {
       requests: [{
         repeat_cell: {
-          range: {
-            sheet_id: 0,
-            start_row_index: 0,
-            end_row_index: 10,
+          range:  {
+            sheet_id:           0,
+            start_row_index:    0,
+            end_row_index:      10,
             start_column_index: 0,
-            end_column_index: 10
+            end_column_index:   10
           },
-          cell: {
+          cell:   {
             user_entered_value: {
               string_value: 'Hello'
             }

--- a/sheets/snippets/spec/spec_helper.rb
+++ b/sheets/snippets/spec/spec_helper.rb
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 spec_dir = __dir__
-root_dir = File.expand_path(File.join(spec_dir, '..'))
-lib_dir = File.expand_path(File.join(root_dir, 'lib'))
+root_dir = File.expand_path File.join(spec_dir, "..")
+lib_dir = File.expand_path File.join(root_dir, "lib")
 
-$LOAD_PATH.unshift(spec_dir)
-$LOAD_PATH.unshift(lib_dir)
+$LOAD_PATH.unshift spec_dir
+$LOAD_PATH.unshift lib_dir
 $LOAD_PATH.uniq!
 
-require 'rspec'
-require 'googleauth'
-require 'google/apis/drive_v3'
-require 'google/apis/sheets_v4'
+require "rspec"
+require "googleauth"
+require "google/apis/drive_v3"
+require "google/apis/sheets_v4"
 
 module TestHelpers
   def build_service
@@ -61,30 +61,30 @@ module TestHelpers
     drive_service.batch do
       @files_to_delete.each do |file_id|
         puts "Deleting file #{file_id}"
-        drive_service.delete_file(file_id) do |res, err|
+        drive_service.delete_file file_id do |res, err|
           # Ignore errors...
         end
       end
     end
   end
 
-  def delete_file_on_cleanup(file_id)
+  def delete_file_on_cleanup file_id
     @files_to_delete << file_id
   end
 
   def create_test_spreadsheet
     spreadsheet = {
       properties: {
-        title: 'Test Spreadsheet'
+        title: "Test Spreadsheet"
       }
     }
     spreadsheet = service.create_spreadsheet(spreadsheet,
-                                             fields: 'spreadsheetId')
-    delete_file_on_cleanup(spreadsheet.spreadsheet_id)
+                                             fields: "spreadsheetId")
+    delete_file_on_cleanup spreadsheet.spreadsheet_id
     spreadsheet.spreadsheet_id
   end
 
-  def populate_values(spreadsheet_id)
+  def populate_values spreadsheet_id
     body = {
       requests: [{
         repeat_cell: {
@@ -97,10 +97,10 @@ module TestHelpers
           },
           cell:   {
             user_entered_value: {
-              string_value: 'Hello'
+              string_value: "Hello"
             }
           },
-          fields: 'userEnteredValue'
+          fields: "userEnteredValue"
         }
       }]
     }

--- a/sheets/snippets/spec/spec_helper.rb
+++ b/sheets/snippets/spec/spec_helper.rb
@@ -25,6 +25,7 @@ require "googleauth"
 require "google/apis/drive_v3"
 require "google/apis/sheets_v4"
 
+# Test helpers
 module TestHelpers
   def build_service
     sheets = Google::Apis::SheetsV4::SheetsService.new

--- a/sheets/snippets/spec/spreadsheet_snippets_spec.rb
+++ b/sheets/snippets/spec/spreadsheet_snippets_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe SpreadsheetSnippets do
   end
 
   it "should update values" do
-    id = create_test_spreadsheet
+    id = create_test_spreadsheetgspe
     result = @snippets.update_values id, "A1:B2", "USER_ENTERED", VALUES_2D
     expect(result).to_not be_nil
     expect(result.updated_rows).to eq(2)

--- a/sheets/snippets/spec/spreadsheet_snippets_spec.rb
+++ b/sheets/snippets/spec/spreadsheet_snippets_spec.rb
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'spec_helper'
-require 'spreadsheet_snippets'
+require "spec_helper"
+require "spreadsheet_snippets"
 
 VALUES_2D = [
   %w[A B],
@@ -23,34 +23,34 @@ VALUES_2D = [
 RSpec.describe SpreadsheetSnippets do
   include TestHelpers
 
-  before(:all) do
-    @snippets = SpreadsheetSnippets.new(build_service)
+  before :all do
+    @snippets = SpreadsheetSnippets.new build_service
     reset
   end
 
-  after(:all) do
+  after :all do
     cleanup_files
   end
 
-  it 'should create a spreadsheet' do
+  it "should create a spreadsheet" do
     id = @snippets.create
     expect(id).to_not be_nil
-    delete_file_on_cleanup(id)
+    delete_file_on_cleanup id
   end
 
-  it 'should batch update a spreadsheet' do
+  it "should batch update a spreadsheet" do
     id = create_test_spreadsheet
-    populate_values(id)
-    result = @snippets.batch_update(id, 'New Title', 'Hello', 'Goodbye')
+    populate_values id
+    result = @snippets.batch_update id, "New Title", "Hello", "Goodbye"
     expect(result.replies.length).to eq(2)
     find_replace_response = result.replies[1].find_replace
     expect(find_replace_response.occurrences_changed).to eq(100)
   end
 
-  it 'should get values' do
+  it "should get values" do
     id = create_test_spreadsheet
-    populate_values(id)
-    result = @snippets.get_values(id, 'A1:C2')
+    populate_values id
+    result = @snippets.get_values id, "A1:C2"
     expect(result).to_not be_nil
     values = result.values
     expect(values).to_not be_nil
@@ -58,10 +58,10 @@ RSpec.describe SpreadsheetSnippets do
     expect(values[0].length).to eq(3)
   end
 
-  it 'should batch get values' do
+  it "should batch get values" do
     id = create_test_spreadsheet
-    populate_values(id)
-    result = @snippets.batch_get_values(id, ['A1:A3', 'B1:C1'])
+    populate_values id
+    result = @snippets.batch_get_values id, ["A1:A3", "B1:C1"]
     value_ranges = result.value_ranges
     expect(result).to_not be_nil
     expect(value_ranges.length).to eq(2)
@@ -69,18 +69,18 @@ RSpec.describe SpreadsheetSnippets do
     expect(values.length).to eq(3)
   end
 
-  it 'should update values' do
+  it "should update values" do
     id = create_test_spreadsheet
-    result = @snippets.update_values(id, 'A1:B2', 'USER_ENTERED', VALUES_2D)
+    result = @snippets.update_values id, "A1:B2", "USER_ENTERED", VALUES_2D
     expect(result).to_not be_nil
     expect(result.updated_rows).to eq(2)
     expect(result.updated_columns).to eq(2)
     expect(result.updated_cells).to eq(4)
   end
 
-  it 'should batch update values' do
+  it "should batch update values" do
     id = create_test_spreadsheet
-    result = @snippets.batch_update_values(id, 'A1:B2', 'USER_ENTERED', VALUES_2D)
+    result = @snippets.batch_update_values id, "A1:B2", "USER_ENTERED", VALUES_2D
     expect(result).to_not be_nil
     responses = result.responses
     expect(responses.length).to eq(1)
@@ -88,30 +88,30 @@ RSpec.describe SpreadsheetSnippets do
     expect(responses[0].updated_columns).to eq(2)
   end
 
-  it 'should append values' do
+  it "should append values" do
     id = create_test_spreadsheet
-    populate_values(id)
-    result = @snippets.append_values(id, 'Sheet1', 'USER_ENTERED', VALUES_2D)
+    populate_values id
+    result = @snippets.append_values id, "Sheet1", "USER_ENTERED", VALUES_2D
     expect(result).to_not be_nil
-    expect(result.table_range).to eq('Sheet1!A1:J10')
+    expect(result.table_range).to eq("Sheet1!A1:J10")
     updates = result.updates
-    expect(updates.updated_range).to eq('Sheet1!A11:B12')
+    expect(updates.updated_range).to eq("Sheet1!A11:B12")
     expect(updates.updated_rows).to eq(2)
     expect(updates.updated_columns).to eq(2)
     expect(updates.updated_cells).to eq(4)
   end
 
-  it 'should create pivot tables' do
+  it "should create pivot tables" do
     id = create_test_spreadsheet
-    populate_values(id)
-    result = @snippets.pivot_tables(id)
+    populate_values id
+    result = @snippets.pivot_tables id
     expect(result).to_not be_nil
   end
 
-  it 'should conditionally format' do
+  it "should conditionally format" do
     id = create_test_spreadsheet
-    populate_values(id)
-    result = @snippets.conditional_formatting(id)
+    populate_values id
+    result = @snippets.conditional_formatting id
     expect(result.spreadsheet_id).to eq(id)
     expect(result.replies.length).to eq(2)
   end

--- a/slides/quickstart/Gemfile
+++ b/slides/quickstart/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.28.4'
+gem "google-api-client", "~> 0.28.4"

--- a/slides/quickstart/quickstart.rb
+++ b/slides/quickstart/quickstart.rb
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START slides_quickstart]
-require 'google/apis/slides_v1'
-require 'googleauth'
-require 'googleauth/stores/file_token_store'
-require 'fileutils'
+require "google/apis/slides_v1"
+require "googleauth"
+require "googleauth/stores/file_token_store"
+require "fileutils"
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
-APPLICATION_NAME = 'Google Slides API Ruby Quickstart'.freeze
-CREDENTIALS_PATH = 'credentials.json'.freeze
+OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
+APPLICATION_NAME = "Google Slides API Ruby Quickstart".freeze
+CREDENTIALS_PATH = "credentials.json".freeze
 # The file token.yaml stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
-TOKEN_PATH = 'token.yaml'.freeze
+TOKEN_PATH = "token.yaml".freeze
 SCOPE = Google::Apis::SlidesV1::AUTH_PRESENTATIONS_READONLY
 
 ##
@@ -33,14 +33,14 @@ SCOPE = Google::Apis::SlidesV1::AUTH_PRESENTATIONS_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
-  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
-  user_id = 'default'
-  credentials = authorizer.get_credentials(user_id)
+  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
+  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
+  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
+  user_id = "default"
+  credentials = authorizer.get_credentials user_id
   if credentials.nil?
-    url = authorizer.get_authorization_url(base_url: OOB_URI)
-    puts 'Open the following URL in the browser and enter the ' \
+    url = authorizer.get_authorization_url base_url: OOB_URI
+    puts "Open the following URL in the browser and enter the " \
          "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
@@ -57,8 +57,8 @@ service.authorization = authorize
 
 # Prints the number of slides and elements in a sample presentation:
 # https://docs.google.com/presentation/d/1EAYk18WDjIG-zp_0vLm3CsfQh_i8eXc67Jo2O9C6Vuc/edit
-presentation_id = '1EAYk18WDjIG-zp_0vLm3CsfQh_i8eXc67Jo2O9C6Vuc'
-presentation = service.get_presentation(presentation_id)
+presentation_id = "1EAYk18WDjIG-zp_0vLm3CsfQh_i8eXc67Jo2O9C6Vuc"
+presentation = service.get_presentation presentation_id
 puts "The presentation contains #{presentation.slides.count} slides:"
 presentation.slides.each_with_index do |slide, i|
   puts "- Slide \##{i + 1} contains #{slide.page_elements.count} elements."

--- a/slides/snippets/Gemfile
+++ b/slides/snippets/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.9'
-gem 'rspec', '~> 3.0'
+gem "google-api-client", "~> 0.9"
+gem "rspec", "~> 3.0"

--- a/slides/snippets/lib/file_snippets.rb
+++ b/slides/snippets/lib/file_snippets.rb
@@ -88,35 +88,36 @@ class FileSnippets
       magnitude: '350',
       unit:      'PT'
     }
-    requests = [{
-      create_shape: {
-        object_id_prop:     element_id,
-        shape_type:         'TEXT_BOX',
-        element_properties: {
-          page_object_id: page_id,
-          size:           {
-            height: pt350,
-            width:  pt350
-          },
-          transform:      {
-            scale_x:     '1',
-            scale_y:     '1',
-            translate_x: '350',
-            translate_y: '100',
-            unit:        'PT'
+    requests = [
+      {
+        create_shape: {
+          object_id_prop:     element_id,
+          shape_type:         'TEXT_BOX',
+          element_properties: {
+            page_object_id: page_id,
+            size:           {
+              height: pt350,
+              width:  pt350
+            },
+            transform:      {
+              scale_x:     '1',
+              scale_y:     '1',
+              translate_x: '350',
+              translate_y: '100',
+              unit:        'PT'
+            }
           }
         }
+      },
+      # Insert text into the box, using the supplied element ID.
+      {
+        insert_text: {
+          object_id_prop:  element_id,
+          insertion_index: 0,
+          text:            'New Box Text Inserted!'
+        }
       }
-    },
-
-                # Insert text into the box, using the supplied element ID.
-                {
-                  insert_text: {
-                    object_id_prop:  element_id,
-                    insertion_index: 0,
-                    text:            'New Box Text Inserted!'
-                  }
-                }]
+    ]
 
     # Execute the request.
     req = Google::Apis::SlidesV1::BatchUpdatePresentationRequest.new(requests: requests)

--- a/slides/snippets/lib/file_snippets.rb
+++ b/slides/snippets/lib/file_snippets.rb
@@ -34,10 +34,10 @@ class FileSnippets
     @sheets_service
   end
 
-  def create_presentation(title='Title')
+  def create_presentation(title = 'Title')
     # [START slides_create_presentation]
     body = Google::Apis::SlidesV1::Presentation.new
-    body.title =  title
+    body.title = title
     presentation = slides_service.create_presentation(body)
     puts "Created presentation with ID: #{presentation.presentation_id}"
     # [END slides_create_presentation]
@@ -60,8 +60,8 @@ class FileSnippets
     body = Google::Apis::SlidesV1::Presentation.new
     requests = [{
       create_slide: {
-        object_id_prop: page_id,
-        insertion_index: '1',
+        object_id_prop:         page_id,
+        insertion_index:        '1',
         slide_layout_reference: {
           predefined_layout: 'TITLE_AND_TWO_COLUMNS'
         }
@@ -86,43 +86,44 @@ class FileSnippets
     element_id = 'MyTextBox_01'
     pt350 = {
       magnitude: '350',
-      unit: 'PT'
+      unit:      'PT'
     }
     requests = [{
       create_shape: {
-        object_id_prop: element_id,
-        shape_type: 'TEXT_BOX',
+        object_id_prop:     element_id,
+        shape_type:         'TEXT_BOX',
         element_properties: {
           page_object_id: page_id,
-          size: {
+          size:           {
             height: pt350,
-            width: pt350
+            width:  pt350
           },
-          transform: {
-            scale_x: '1',
-            scale_y: '1',
+          transform:      {
+            scale_x:     '1',
+            scale_y:     '1',
             translate_x: '350',
             translate_y: '100',
-            unit: 'PT'
+            unit:        'PT'
           }
         }
       }
     },
 
-    # Insert text into the box, using the supplied element ID.
-    {
-      insert_text: {
-        object_id_prop: element_id,
-        insertion_index: 0,
-        text: 'New Box Text Inserted!'
-      }
-    }]
+                # Insert text into the box, using the supplied element ID.
+                {
+                  insert_text: {
+                    object_id_prop:  element_id,
+                    insertion_index: 0,
+                    text:            'New Box Text Inserted!'
+                  }
+                }]
 
     # Execute the request.
     req = Google::Apis::SlidesV1::BatchUpdatePresentationRequest.new(requests: requests)
     response = slides_service.batch_update_presentation(
       presentation_id,
-      req)
+      req
+    )
     create_shape_response = response.replies[0].create_shape
     puts "Created textbox with ID: #{create_shape_response.object_id}"
     # [END slides_create_textbox_with_text]
@@ -142,24 +143,24 @@ class FileSnippets
     image_id = 'MyImage_01'
     emu4M = {
       magnitude: '4000000',
-      unit: 'EMU'
+      unit:      'EMU'
     }
     requests << {
       create_image: {
-        object_id_prop: image_id,
-        url: IMAGE_URL,
+        object_id_prop:     image_id,
+        url:                IMAGE_URL,
         element_properties: {
           page_object_id: page_id,
-          size: {
+          size:           {
             height: emu4M,
-            width: emu4M
+            width:  emu4M
           },
-          transform: {
-            scale_x: '1',
-            scale_y: '1',
+          transform:      {
+            scale_x:     '1',
+            scale_y:     '1',
             translate_x: '100000',
             translate_y: '100000',
-            unit: 'EMU'
+            unit:        'EMU'
           }
         }
       }
@@ -169,7 +170,8 @@ class FileSnippets
     req = Google::Apis::SlidesV1::BatchUpdatePresentationRequest.new(requests: requests)
     response = slides_service.batch_update_presentation(
       presentation_id,
-      req)
+      req
+    )
     create_image_response = response.replies[0].create_image
     puts "Created image with ID: #{create_image_response.object_id}"
     # [END slides_create_image]
@@ -183,7 +185,8 @@ class FileSnippets
     data_range_notation = 'Customers!A2:M6'
     sheets_response = sheets_service.get_spreadsheet_values(
       data_spreadsheet_id,
-      data_range_notation)
+      data_range_notation
+    )
     values = sheets_response.values
 
     # For each record, create a new merged presentation.
@@ -203,26 +206,26 @@ class FileSnippets
       requests = [] << {
         replace_all_text: {
           contains_text: {
-            text: '{{customer-name}}',
+            text:       '{{customer-name}}',
             match_case: true
           },
-          replace_text: customer_name
+          replace_text:  customer_name
         }
       } << {
         replace_all_text: {
           contains_text: {
-            text: '{{case-description}}',
+            text:       '{{case-description}}',
             match_case: true
           },
-          replace_text: case_description
+          replace_text:  case_description
         }
       } << {
         replace_all_text: {
           contains_text: {
-            text: '{{total-portfolio}}',
+            text:       '{{total-portfolio}}',
             match_case: true
           },
-          replace_text: total_portfolio
+          replace_text:  total_portfolio
         }
       }
 
@@ -230,7 +233,8 @@ class FileSnippets
       req = Google::Apis::SlidesV1::BatchUpdatePresentationRequest.new(requests: requests)
       response = slides_service.batch_update_presentation(
         presentation_copy_id,
-        req)
+        req
+      )
       # [START_EXCLUDE silent]
       responses << response
       # [END_EXCLUDE silent]
@@ -261,19 +265,19 @@ class FileSnippets
     # Create the image merge (replace_all_shapes_with_image) requests.
     requests = [] << {
       replace_all_shapes_with_image: {
-        image_url: logo_url,
+        image_url:      logo_url,
         replace_method: 'CENTER_INSIDE',
-        contains_text: {
-          text: '{{company-logo}}',
+        contains_text:  {
+          text:       '{{company-logo}}',
           match_case: true
         }
       }
     } << {
       replace_all_shapes_with_image: {
-        image_url: customer_graphic_url,
+        image_url:      customer_graphic_url,
         replace_method: 'CENTER_INSIDE',
-        contains_text: {
-          text: '{{customer-graphic}}',
+        contains_text:  {
+          text:       '{{customer-graphic}}',
           match_case: true
         }
       }
@@ -283,7 +287,8 @@ class FileSnippets
     req = Google::Apis::SlidesV1::BatchUpdatePresentationRequest.new(requests: requests)
     response = slides_service.batch_update_presentation(
       presentation_copy_id,
-      req)
+      req
+    )
 
     # Count the number of replacements made.
     num_replacements = 0
@@ -302,15 +307,15 @@ class FileSnippets
     requests = [] << {
       delete_text: {
         object_id_prop: shape_id,
-        text_range: {
+        text_range:     {
           type: 'ALL'
         }
       }
     } << {
       insert_text: {
-        object_id_prop: shape_id,
+        object_id_prop:  shape_id,
         insertion_index: 0,
-        text: replacement_text
+        text:            replacement_text
       }
     }
 
@@ -318,7 +323,8 @@ class FileSnippets
     req = Google::Apis::SlidesV1::BatchUpdatePresentationRequest.new(requests: requests)
     response = slides_service.batch_update_presentation(
       presentation_id,
-      req)
+      req
+    )
     puts "Replaced text in shape with ID: #{shape_id}"
     # [END slides_simple_text_replace]
     response
@@ -332,57 +338,57 @@ class FileSnippets
     requests = [] << {
       update_text_style: {
         object_id_prop: shape_id,
-        text_range: {
-          type: 'FIXED_RANGE',
+        text_range:     {
+          type:        'FIXED_RANGE',
           start_index: 0,
-          end_index: 5
+          end_index:   5
         },
-        style: {
-          bold: true,
+        style:          {
+          bold:   true,
           italic: true
         },
-        fields: 'bold,italic'
+        fields:         'bold,italic'
       }
     } << {
       update_text_style: {
         object_id_prop: shape_id,
-        text_range: {
-          type: 'FIXED_RANGE',
+        text_range:     {
+          type:        'FIXED_RANGE',
           start_index: 5,
-          end_index: 10
+          end_index:   10
         },
-        style: {
-          font_family: 'Times New Roman',
-          font_size: {
+        style:          {
+          font_family:      'Times New Roman',
+          font_size:        {
             magnitude: 14,
-            unit: 'PT'
+            unit:      'PT'
           },
           foreground_color: {
             opaque_color: {
               rgb_color: {
-                blue: 1.0,
+                blue:  1.0,
                 green: 0.0,
-                red: 0.0
+                red:   0.0
               }
             }
           }
         },
-        fields: 'foreground_color,font_family,font_size'
+        fields:         'foreground_color,font_family,font_size'
       }
     } << {
       update_text_style: {
         object_id_prop: shape_id,
-        text_range: {
-          type: 'FIXED_RANGE',
+        text_range:     {
+          type:        'FIXED_RANGE',
           start_index: 10,
-          end_index: 15
+          end_index:   15
         },
-        style: {
+        style:          {
           link: {
             url: 'www.example.com'
           }
         },
-        fields: 'link'
+        fields:         'link'
       }
     }
 
@@ -400,10 +406,10 @@ class FileSnippets
     requests = [] << {
       create_paragraph_bullets: {
         object_id_prop: shape_id,
-        text_range: {
+        text_range:     {
           type: 'ALL'
         },
-        bulletPreset: 'BULLET_ARROW_DIAMOND_DISC'
+        bulletPreset:   'BULLET_ARROW_DIAMOND_DISC'
       }
     }
 
@@ -422,27 +428,27 @@ class FileSnippets
     # chart to be refreshed if the Sheets version is updated.
     emu4M = {
       magnitude: 4000000,
-      unit: 'EMU'
+      unit:      'EMU'
     }
     presentation_chart_id = 'my_embedded_chart'
     requests = [{
       create_sheets_chart: {
-        object_id_prop: presentation_chart_id,
-        spreadsheet_id: spreadsheet_id,
-        chart_id: sheet_chart_id,
-        linking_mode: 'LINKED',
+        object_id_prop:     presentation_chart_id,
+        spreadsheet_id:     spreadsheet_id,
+        chart_id:           sheet_chart_id,
+        linking_mode:       'LINKED',
         element_properties: {
           page_object_id: page_id,
-          size: {
+          size:           {
             height: emu4M,
-            width: emu4M
+            width:  emu4M
           },
-          transform: {
-            scale_x: 1,
-            scale_y: 1,
+          transform:      {
+            scale_x:     1,
+            scale_y:     1,
             translate_x: 100000,
             translate_y: 100000,
-            unit: 'EMU'
+            unit:        'EMU'
           }
         }
       }

--- a/slides/snippets/spec/file_snippets_spec.rb
+++ b/slides/snippets/spec/file_snippets_spec.rb
@@ -12,73 +12,73 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'spec_helper'
-require 'file_snippets'
+require "spec_helper"
+require "file_snippets"
 
 RSpec.describe FileSnippets do
   include TestHelpers
 
-  IMAGE_FILE_PATH = '../images/googlelogo_color_272x92dp.png'.freeze
-  IMAGE_URL = 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png'.freeze
-  IMAGE_MIMETYPE = 'image/png'.freeze
-  TEMPLATE_PRESENTATION_ID = '1MmTR712m7U_kgeweE57POWwkEyWAV17AVAWjpmltmIg'.freeze
-  DATA_SPREADSHEET_ID = '14KaZMq2aCAGt5acV77zaA_Ps8aDt04G7T0ei4KiXLX8'.freeze
+  IMAGE_FILE_PATH = "../images/googlelogo_color_272x92dp.png".freeze
+  IMAGE_URL = "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png".freeze
+  IMAGE_MIMETYPE = "image/png".freeze
+  TEMPLATE_PRESENTATION_ID = "1MmTR712m7U_kgeweE57POWwkEyWAV17AVAWjpmltmIg".freeze
+  DATA_SPREADSHEET_ID = "14KaZMq2aCAGt5acV77zaA_Ps8aDt04G7T0ei4KiXLX8".freeze
   CHART_ID = 1107320627 # rubocop:disable Style/NumericLiterals
-  CUSTOMER_NAME = 'Fake Customer'.freeze
+  CUSTOMER_NAME = "Fake Customer".freeze
 
-  before(:all) do
+  before :all do
     @snippets = FileSnippets.new(build_drive_service,
                                  build_slides_service,
                                  build_sheets_service)
     reset
   end
 
-  after(:all) do
+  after :all do
     cleanup_files
   end
 
-  it 'should create a presentation' do
-    presentation = @snippets.create_presentation('Title')
+  it "should create a presentation" do
+    presentation = @snippets.create_presentation "Title"
     expect(presentation).to_not be_nil
-    delete_file_on_cleanup(presentation.presentation_id)
+    delete_file_on_cleanup presentation.presentation_id
   end
 
-  it 'should copy a presentation' do
+  it "should copy a presentation" do
     presentation_id = create_test_presentation
-    copy_id = @snippets.copy_presentation(presentation_id, 'My Duplicate Presentation')
+    copy_id = @snippets.copy_presentation presentation_id, "My Duplicate Presentation"
     expect(copy_id).to_not be_nil
-    delete_file_on_cleanup(copy_id)
+    delete_file_on_cleanup copy_id
   end
 
-  it 'should create a slide' do
+  it "should create a slide" do
     presentation_id = create_test_presentation
-    add_slides(presentation_id, 3, 'TITLE_AND_TWO_COLUMNS')
-    page_id = 'my_page_id'
-    response = @snippets.create_slide(presentation_id, page_id)
+    add_slides presentation_id, 3, "TITLE_AND_TWO_COLUMNS"
+    page_id = "my_page_id"
+    response = @snippets.create_slide presentation_id, page_id
     expect(response.object_id_prop).to eq(page_id)
-    delete_file_on_cleanup(presentation_id)
+    delete_file_on_cleanup presentation_id
   end
 
-  it 'should create a textbox with text' do
+  it "should create a textbox with text" do
     presentation_id = create_test_presentation
-    page_id = add_slides(presentation_id, 1, 'BLANK')[0]
-    response = @snippets.create_textbox_with_text(presentation_id, page_id)
+    page_id = add_slides(presentation_id, 1, "BLANK")[0]
+    response = @snippets.create_textbox_with_text presentation_id, page_id
     expect(response.replies.length).to eq(2)
     box_id = response.replies[0].create_shape.object_id_prop
     expect(box_id).to_not be_nil
   end
 
-  it 'should create an image' do
+  it "should create an image" do
     presentation_id = create_test_presentation
-    page_id = add_slides(presentation_id, 1, 'BLANK')[0]
-    response = @snippets.create_image(presentation_id, page_id, IMAGE_FILE_PATH, IMAGE_MIMETYPE)
+    page_id = add_slides(presentation_id, 1, "BLANK")[0]
+    response = @snippets.create_image presentation_id, page_id, IMAGE_FILE_PATH, IMAGE_MIMETYPE
     expect(response.replies.length).to eq(1)
     image_id = response.replies[0].create_image.object_id_prop
     expect(image_id).to_not be_nil
   end
 
-  it 'should text merge' do
-    responses = @snippets.text_merging(TEMPLATE_PRESENTATION_ID, DATA_SPREADSHEET_ID)
+  it "should text merge" do
+    responses = @snippets.text_merging TEMPLATE_PRESENTATION_ID, DATA_SPREADSHEET_ID
     responses.each do |response|
       presentation_id = response.presentation_id
       expect(presentation_id).to_not be_nil
@@ -88,11 +88,11 @@ RSpec.describe FileSnippets do
         num_replacements += reply.replace_all_text.occurrences_changed
       end
       expect(num_replacements).to eq(4)
-      delete_file_on_cleanup(presentation_id)
+      delete_file_on_cleanup presentation_id
     end
   end
 
-  it 'should image merge' do
+  it "should image merge" do
     response = @snippets.image_merging(TEMPLATE_PRESENTATION_ID,
                                        IMAGE_URL,
                                        CUSTOMER_NAME)
@@ -104,36 +104,36 @@ RSpec.describe FileSnippets do
       num_replacements += reply.replace_all_shapes_with_image.occurrences_changed
     end
     expect(num_replacements).to eq(2)
-    delete_file_on_cleanup(presentation_id)
+    delete_file_on_cleanup presentation_id
   end
 
-  it 'should simple text replace' do
+  it "should simple text replace" do
     presentation_id = create_test_presentation
-    page_id = add_slides(presentation_id, 1, 'BLANK')[0]
-    box_id = create_test_textbox(presentation_id, page_id)
-    response = @snippets.simple_text_replace(presentation_id, box_id, 'MY NEW TEXT')
+    page_id = add_slides(presentation_id, 1, "BLANK")[0]
+    box_id = create_test_textbox presentation_id, page_id
+    response = @snippets.simple_text_replace presentation_id, box_id, "MY NEW TEXT"
     expect(response.replies.length).to eq(2)
   end
 
-  it 'should text style update' do
+  it "should text style update" do
     presentation_id = create_test_presentation
-    page_id = add_slides(presentation_id, 1, 'BLANK')[0]
-    box_id = create_test_textbox(presentation_id, page_id)
-    response = @snippets.text_style_update(presentation_id, box_id)
+    page_id = add_slides(presentation_id, 1, "BLANK")[0]
+    box_id = create_test_textbox presentation_id, page_id
+    response = @snippets.text_style_update presentation_id, box_id
     expect(response.replies.length).to eq(3)
   end
 
-  it 'should create bulleted text' do
+  it "should create bulleted text" do
     presentation_id = create_test_presentation
-    page_id = add_slides(presentation_id, 1, 'BLANK')[0]
-    box_id = create_test_textbox(presentation_id, page_id)
-    response = @snippets.create_bulleted_text(presentation_id, box_id)
+    page_id = add_slides(presentation_id, 1, "BLANK")[0]
+    box_id = create_test_textbox presentation_id, page_id
+    response = @snippets.create_bulleted_text presentation_id, box_id
     expect(response.replies.length).to eq(1)
   end
 
-  it 'should create a sheets chart' do
+  it "should create a sheets chart" do
     presentation_id = create_test_presentation
-    page_id = add_slides(presentation_id, 1, 'BLANK')[0]
+    page_id = add_slides(presentation_id, 1, "BLANK")[0]
     response = @snippets.create_sheets_chart(presentation_id,
                                              page_id,
                                              DATA_SPREADSHEET_ID,
@@ -143,9 +143,9 @@ RSpec.describe FileSnippets do
     expect(chart_id).to_not be_nil
   end
 
-  it 'should refresh sheets chart' do
+  it "should refresh sheets chart" do
     presentation_id = create_test_presentation
-    page_id = add_slides(presentation_id, 1, 'BLANK')[0]
+    page_id = add_slides(presentation_id, 1, "BLANK")[0]
     chart_id = create_test_sheets_chart(presentation_id,
                                         page_id,
                                         DATA_SPREADSHEET_ID,

--- a/slides/snippets/spec/spec_helper.rb
+++ b/slides/snippets/spec/spec_helper.rb
@@ -13,18 +13,18 @@
 # limitations under the License.
 
 spec_dir = __dir__
-root_dir = File.expand_path(File.join(spec_dir, '..'))
-lib_dir = File.expand_path(File.join(root_dir, 'lib'))
+root_dir = File.expand_path File.join(spec_dir, "..")
+lib_dir = File.expand_path File.join(root_dir, "lib")
 
-$LOAD_PATH.unshift(spec_dir)
-$LOAD_PATH.unshift(lib_dir)
+$LOAD_PATH.unshift spec_dir
+$LOAD_PATH.unshift lib_dir
 $LOAD_PATH.uniq!
 
-require 'rspec'
-require 'googleauth'
-require 'google/apis/slides_v1'
-require 'google/apis/sheets_v4'
-require 'google/apis/drive_v3'
+require "rspec"
+require "googleauth"
+require "google/apis/slides_v1"
+require "google/apis/sheets_v4"
+require "google/apis/drive_v3"
 
 module TestHelpers
   def build_drive_service
@@ -76,7 +76,7 @@ module TestHelpers
     drive_service.batch do
       @files_to_delete.each do |file_id|
         puts "Deleting file #{file_id}"
-        drive_service.delete_file(file_id) do |res, err|
+        drive_service.delete_file file_id do |res, err|
           # Ignore errors...
         end
       end
@@ -85,16 +85,16 @@ module TestHelpers
 
   def create_test_presentation
     presentation = slides_service.create_presentation(
-      'title' => 'Test Preso'
+      "title" => "Test Preso"
     )
     presentation.presentation_id
   end
 
-  def delete_file_on_cleanup(file_id)
+  def delete_file_on_cleanup file_id
     @files_to_delete << file_id
   end
 
-  def add_slides(presentation_id, num, layout = 'TITLE_AND_TWO_COLUMNS')
+  def add_slides presentation_id, num, layout = "TITLE_AND_TWO_COLUMNS"
     requests = []
     slide_ids = []
     (0..num).each do |i|
@@ -109,21 +109,21 @@ module TestHelpers
       }
     end
 
-    req = Google::Apis::SlidesV1::BatchUpdatePresentationRequest.new(requests: requests)
-    slides_service.batch_update_presentation(presentation_id, req)
+    req = Google::Apis::SlidesV1::BatchUpdatePresentationRequest.new requests: requests
+    slides_service.batch_update_presentation presentation_id, req
     slide_ids
   end
 
-  def create_test_textbox(presentation_id, page_id)
-    box_id = 'MyTextBox_01'
+  def create_test_textbox presentation_id, page_id
+    box_id = "MyTextBox_01"
     pt350 = {
       magnitude: 350,
-      unit:      'PT'
+      unit:      "PT"
     }
     requests = [] << {
       create_shape: {
         object_id_prop:     box_id,
-        shape_type:         'TEXT_BOX',
+        shape_type:         "TEXT_BOX",
         element_properties: {
           page_object_id: page_id,
           size:           {
@@ -135,7 +135,7 @@ module TestHelpers
             scale_y:     1,
             translate_x: 350,
             translate_y: 100,
-            unit:        'PT'
+            unit:        "PT"
           }
         }
       }
@@ -143,27 +143,27 @@ module TestHelpers
       insert_text: {
         object_id_prop:  box_id,
         insertion_index: 0,
-        text:            'New Box Text Inserted'
+        text:            "New Box Text Inserted"
       }
     }
 
-    req = Google::Apis::SlidesV1::BatchUpdatePresentationRequest.new(requests: requests)
-    response = slides_service.batch_update_presentation(presentation_id, req)
+    req = Google::Apis::SlidesV1::BatchUpdatePresentationRequest.new requests: requests
+    response = slides_service.batch_update_presentation presentation_id, req
     response.replies[0].create_shape.object_id_prop
   end
 
-  def create_test_sheets_chart(presentation_id, page_id, spreadsheet_id, sheet_chart_id)
-    chart_id = 'MyChart_01'
+  def create_test_sheets_chart presentation_id, page_id, spreadsheet_id, sheet_chart_id
+    chart_id = "MyChart_01"
     emu4m = {
       magnitude: 4_000_000,
-      unit:      'EMU'
+      unit:      "EMU"
     }
     requests = [] << {
       create_sheets_chart: {
         object_id_prop:     chart_id,
         spreadsheet_id:     spreadsheet_id,
         chart_id:           sheet_chart_id,
-        linking_mode:       'LINKED',
+        linking_mode:       "LINKED",
         element_properties: {
           page_object_id: page_id,
           size:           {
@@ -175,14 +175,14 @@ module TestHelpers
             scale_y:     1,
             translate_x: 100_000,
             translate_y: 100_000,
-            unit:        'EMU'
+            unit:        "EMU"
           }
         }
       }
     }
 
-    req = Google::Apis::SlidesV1::BatchUpdatePresentationRequest.new(requests: requests)
-    response = slides_service.batch_update_presentation(presentation_id, req)
+    req = Google::Apis::SlidesV1::BatchUpdatePresentationRequest.new requests: requests
+    response = slides_service.batch_update_presentation presentation_id, req
     response.replies[0].create_sheets_chart.object_id_prop
   end
 end

--- a/slides/snippets/spec/spec_helper.rb
+++ b/slides/snippets/spec/spec_helper.rb
@@ -101,7 +101,7 @@ module TestHelpers
       slide_ids << "slide_#{i}"
       requests << {
         create_slide: {
-          object_id_prop: slide_ids[i],
+          object_id_prop:         slide_ids[i],
           slide_layout_reference: {
             predefined_layout: layout
           }
@@ -118,32 +118,32 @@ module TestHelpers
     box_id = 'MyTextBox_01'
     pt350 = {
       magnitude: 350,
-      unit: 'PT'
+      unit:      'PT'
     }
     requests = [] << {
       create_shape: {
-        object_id_prop: box_id,
-        shape_type: 'TEXT_BOX',
+        object_id_prop:     box_id,
+        shape_type:         'TEXT_BOX',
         element_properties: {
           page_object_id: page_id,
-          size: {
+          size:           {
             height: pt350,
-            width: pt350
+            width:  pt350
           },
-          transform: {
-            scale_x: 1,
-            scale_y: 1,
+          transform:      {
+            scale_x:     1,
+            scale_y:     1,
             translate_x: 350,
             translate_y: 100,
-            unit: 'PT'
+            unit:        'PT'
           }
         }
       }
     } << {
       insert_text: {
-        object_id_prop: box_id,
+        object_id_prop:  box_id,
         insertion_index: 0,
-        text: 'New Box Text Inserted'
+        text:            'New Box Text Inserted'
       }
     }
 
@@ -156,26 +156,26 @@ module TestHelpers
     chart_id = 'MyChart_01'
     emu4m = {
       magnitude: 4_000_000,
-      unit: 'EMU'
+      unit:      'EMU'
     }
     requests = [] << {
       create_sheets_chart: {
-        object_id_prop: chart_id,
-        spreadsheet_id: spreadsheet_id,
-        chart_id: sheet_chart_id,
-        linking_mode: 'LINKED',
+        object_id_prop:     chart_id,
+        spreadsheet_id:     spreadsheet_id,
+        chart_id:           sheet_chart_id,
+        linking_mode:       'LINKED',
         element_properties: {
           page_object_id: page_id,
-          size: {
+          size:           {
             height: emu4m,
-            width: emu4m
+            width:  emu4m
           },
-          transform: {
-            scale_x: 1,
-            scale_y: 1,
+          transform:      {
+            scale_x:     1,
+            scale_y:     1,
             translate_x: 100_000,
             translate_y: 100_000,
-            unit: 'EMU'
+            unit:        'EMU'
           }
         }
       }

--- a/slides/snippets/spec/spec_helper.rb
+++ b/slides/snippets/spec/spec_helper.rb
@@ -26,6 +26,7 @@ require "google/apis/slides_v1"
 require "google/apis/sheets_v4"
 require "google/apis/drive_v3"
 
+# Test helper
 module TestHelpers
   def build_drive_service
     drive = Google::Apis::DriveV3::DriveService.new

--- a/tasks/quickstart/Gemfile
+++ b/tasks/quickstart/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'google-api-client', '~> 0.28.4'
+gem "google-api-client", "~> 0.28.4"

--- a/tasks/quickstart/quickstart.rb
+++ b/tasks/quickstart/quickstart.rb
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START tasks_quickstart]
-require 'google/apis/tasks_v1'
-require 'googleauth'
-require 'googleauth/stores/file_token_store'
-require 'fileutils'
+require "google/apis/tasks_v1"
+require "googleauth"
+require "googleauth/stores/file_token_store"
+require "fileutils"
 
-OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'.freeze
-APPLICATION_NAME = 'Google Tasks API Ruby Quickstart'.freeze
-CREDENTIALS_PATH = 'credentials.json'.freeze
+OOB_URI = "urn:ietf:wg:oauth:2.0:oob".freeze
+APPLICATION_NAME = "Google Tasks API Ruby Quickstart".freeze
+CREDENTIALS_PATH = "credentials.json".freeze
 # The file token.yaml stores the user's access and refresh tokens, and is
 # created automatically when the authorization flow completes for the first
 # time.
-TOKEN_PATH = 'token.yaml'.freeze
+TOKEN_PATH = "token.yaml".freeze
 SCOPE = Google::Apis::TasksV1::AUTH_TASKS_READONLY
 
 ##
@@ -33,14 +33,14 @@ SCOPE = Google::Apis::TasksV1::AUTH_TASKS_READONLY
 #
 # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 def authorize
-  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
-  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
-  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
-  user_id = 'default'
-  credentials = authorizer.get_credentials(user_id)
+  client_id = Google::Auth::ClientId.from_file CREDENTIALS_PATH
+  token_store = Google::Auth::Stores::FileTokenStore.new file: TOKEN_PATH
+  authorizer = Google::Auth::UserAuthorizer.new client_id, SCOPE, token_store
+  user_id = "default"
+  credentials = authorizer.get_credentials user_id
   if credentials.nil?
-    url = authorizer.get_authorization_url(base_url: OOB_URI)
-    puts 'Open the following URL in the browser and enter the ' \
+    url = authorizer.get_authorization_url base_url: OOB_URI
+    puts "Open the following URL in the browser and enter the " \
          "resulting code after authorization:\n" + url
     code = gets
     credentials = authorizer.get_and_store_credentials_from_code(
@@ -56,9 +56,9 @@ service.client_options.application_name = APPLICATION_NAME
 service.authorization = authorize
 
 # Print the first 10 task lists.
-response = service.list_tasklists(max_results: 10)
-puts 'Task lists:'
-puts 'No task lists found' if response.items.empty?
+response = service.list_tasklists max_results: 10
+puts "Task lists:"
+puts "No task lists found" if response.items.empty?
 response.items.each do |task_list|
   puts "#{task_list.title} (#{task_list.id})"
 end


### PR DESCRIPTION
Extends [Google's new Ruby Style lint rules](https://github.com/googleapis/ruby-style).

There currently are a handful of offenses:

```
rubocop
Inspecting 42 files
.CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC

Offenses:
42 files inspected, 606 offenses detected
```

Uses `--fix` to fix a few of them.